### PR TITLE
Hide the edit and history tabs when their URLs are not configured

### DIFF
--- a/includes/Hooks/Hider.php
+++ b/includes/Hooks/Hider.php
@@ -35,5 +35,17 @@ class Hider implements
 				$links[$key] = [];
 			}
 		}
+
+		// The edit and history tabs only make sense when they point at the
+		// external URLs configured via $wgWikvenEditUrl / $wgWikvenHistoryUrl.
+		// Without those, GetLocalURL falls back to a self-link (./Page.html),
+		// so drop the tabs instead of rendering dead links.
+		global $wgWikvenEditUrl, $wgWikvenHistoryUrl;
+		if ( !$wgWikvenEditUrl ) {
+			unset( $links['views']['edit'], $links['views']['ve-edit'], $links['views']['viewsource'] );
+		}
+		if ( !$wgWikvenHistoryUrl ) {
+			unset( $links['views']['history'] );
+		}
 	}
 }


### PR DESCRIPTION
Fixes #11

When `$wgWikvenEditUrl` or `$wgWikvenHistoryUrl` is empty, the `GetLocalURL` hook in `Main.php` falls back to a self-link (`./Page.html`), so the Edit and History tabs rendered as dead links on the static output.

This extends `Hider::onSkinTemplateNavigation__Universal` to drop the `edit` / `ve-edit` / `viewsource` tabs when `$wgWikvenEditUrl` is not set, and the `history` tab when `$wgWikvenHistoryUrl` is not set. When the URLs are configured (e.g. pointing at a GitHub edit/history page), the tabs keep working as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)