### PR TITLE
Set the real last-modified date on the footer

### DIFF
--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -2,16 +2,13 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use CommentStoreComment;
 use ContentHandler;
 use Maintenance;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRecord;
-use Status;
-use StatusValue;
 use StubGlobalUser;
 use Title;
 use User;
+use WikiRevision;
 
 $IP = strval( getenv( 'MW_INSTALL_PATH' ) ) !== ''
 	? getenv( 'MW_INSTALL_PATH' )
@@ -27,66 +24,54 @@ class ImportWikitext extends Maintenance {
 
 	public function execute() {
 		global $wgWikvenSourceDirectory;
-		if ( str_ends_with( $wgWikvenSourceDirectory, '/' ) ) {
-			$wgWikvenSourceDirectory = rtrim( $$wgWikvenSourceDirectory, '/' );
-		}
-
-		$slot = SlotRecord::MAIN;
+		$sourceDirectory = rtrim( $wgWikvenSourceDirectory, '/' );
 
 		$user = User::newSystemUser( User::MAINTENANCE_SCRIPT_USER, [ 'steal' => true ] );
 		StubGlobalUser::setUser( $user );
 
-		$status = StatusValue::newGood();
-		foreach ( glob( "$wgWikvenSourceDirectory/*.wikitext" ) as $filename ) {
+		$ok = true;
+		foreach ( glob( "$sourceDirectory/*.wikitext" ) as $filename ) {
 			$title = Title::newFromText( $this->filenameToTitle( $filename ) );
 			if ( !$title ) {
-				$this->output( "Invalid title: $title" );
+				$this->output( 'Invalid title: ' . basename( $filename ) . "\n" );
 				continue;
 			}
 
-			$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
-
-			# Read the text
 			$text = file_get_contents( $filename );
-
 			$content = ContentHandler::makeContent( $text, $title );
 
-			# Do the edit
+			// Import as an old revision (like core's importTextFiles.php with
+			// --use-timestamp) so the source file's modification time becomes the
+			// revision timestamp and the footer shows the real last-modified date
+			// instead of the build time.
 			$this->output( "Saving... $title" );
-			$updater = $page->newPageUpdater( $user );
+			$revision = new WikiRevision();
+			$revision->setContent( SlotRecord::MAIN, $content );
+			$revision->setTitle( $title );
+			$revision->setUserObj( $user );
+			$revision->setComment( '' );
+			$revision->setTimestamp( wfTimestamp( TS_UNIX, filemtime( $filename ) ) );
 
-			if ( $content === false ) {
-				$updater->removeSlot( $slot );
-			} else {
-				$updater->setContent( $slot, $content );
-			}
-
-			$updater->saveRevision( CommentStoreComment::newUnsavedComment( '' ), EDIT_SUPPRESS_RC );
-			$subStatus = $updater->getStatus();
-
-			if ( $subStatus->isOK() ) {
+			if ( $revision->importOldRevision() ) {
 				$this->output( " done\n" );
 			} else {
 				$this->output( " failed\n" );
+				$ok = false;
 			}
-			$status->merge( $subStatus );
 		}
 
-		if ( !$status->isGood() ) {
-			$this->output( Status::wrap( $status )->getMessage( false, false, 'en' )->text() . "\n" );
-		}
-		return $status->isOK();
+		return $ok;
 	}
 
 	/**
 	 * @param string $name
 	 * @return string
 	 */
-  private function filenameToTitle( $name ) {
+	private function filenameToTitle( $name ) {
 		$name = basename( $name );
 		$name = preg_replace( '/\.wikitext$/', '', $name );
 		return $name;
-  }
+	}
 }
 
 $maintClass = ImportWikitext::class;


### PR DESCRIPTION
Fixes #12

Previously every page was saved through `PageUpdater` at build time, so the footer's last-edited line always showed the build timestamp.

Changes:
- `importWikitext.php` now imports each page as an old revision via `WikiRevision::importOldRevision()` (the same mechanism as core's `importTextFiles.php --use-timestamp`), with the revision timestamp taken from the source file's mtime, so the footer shows a meaningful date.
- Author display is intentionally left out for now: a page can have multiple authors, and attributing everything to a single configured name would misattribute the work. Deriving per-file authorship (e.g. from git history) can be a follow-up.
- Drive-by fix: the old code had a stray `$$wgWikvenSourceDirectory` variable variable in the `rtrim` call.

Caveat: a fresh CI checkout sets every file's mtime to the clone time. Builds that want accurate dates should restore mtimes from git history first (e.g. `git-restore-mtime`) before running the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)