### PR TITLE
docs: wrap Template:ml in <onlyinclude> so it emits no trailing newline

### DIFF
--- a/docs/Template:ml.wikitext
+++ b/docs/Template:ml.wikitext
@@ -1,9 +1,8 @@
-<!--
+<onlyinclude>[[mw:Special:MyLanguage/{{{1|}}}|{{{2|{{{1|}}}}}}]]</onlyinclude><!--
 Links on the article on MediaWikiWiki(https://www.mediawiki.org/).
 
 Usage:
 
 * {{ml|link target on MediaWikiWiki}}
 * {{ml|link target on MediaWikiWiki|label}}
-
--->[[mw:Special:MyLanguage/{{{1|}}}|{{{2|{{{1|}}}}}}]]
+-->


### PR DESCRIPTION
## Problem

On the [published index page](https://chaotic-ground.github.io/wikven/index.html), `and CodeEditor` is wrongly rendered inside a `<pre>` block.

`Template:ml` expanded to `[[link]]\n`. In the inline list item:

```
* All editors ({{ml|...WikiEditor}}, <!--
-->{{ml|...VisualEditor}} and {{ml|...CodeEditor}})
```

the injected newlines turned the source into:

```
* All editors ([[WikiEditor]]
, [[VisualEditor]]
 and [[CodeEditor]]      ← leading space → <pre>
)
```

A line starting with a space is rendered as preformatted text, which is why "and CodeEditor" became a `<pre>` block.

## Fix

The trailing newline comes from the text transcluded after the link. An `<includeonly>…</includeonly><noinclude>…</noinclude>` split is **not** enough: the file's final newline sits after `</noinclude>`, outside both tags, so it is still transcluded (confirmed via a parser dump). Wrap the link in `<onlyinclude>` instead, which transcludes exactly the wrapped content and ignores all surrounding text and whitespace.

## Verification

Reproduced the published site with a full docker build (`docker build` + `docker run … wikven`) and checked the generated `dist/index.html`:

- Parser dump: `X({{ml|A}}, {{ml|B}})Y` → `X(A, B)Y` on one line (was `X(A\n, B\n)Y`).
- Rendered list item: `All editors (WikiEditor, VisualEditor and CodeEditor)`, no `<pre>` (`<pre>and` count went from 1 to 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


BEGIN_COMMIT_OVERRIDE
docs: wrap Template:ml in <onlyinclude> so it emits no trailing newline
END_COMMIT_OVERRIDE
