### PR TITLE
feat: persist Vector "move to sidebar" pin state on the static export

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -15,6 +15,10 @@
 	"ResourceModules": {
 		"ext.Wikven.styles": {
 			"styles": ["ext.Wikven.styles.less"]
+		},
+		"ext.Wikven.pinnableState": {
+			"scripts": ["pinnable-state.js"],
+			"dependencies": ["mediawiki.storage"]
 		}
 	},
 	"ResourceModuleSkinStyles": {

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -9,6 +9,7 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 	/** @inheritDoc */
 	public function onBeforePageDisplay($out, $skin): void {
 		$out->addModuleStyles('ext.Wikven.styles');
+		$out->addModules('ext.Wikven.pinnableState');
 	}
 
 	/** @inheritDoc */

--- a/resources/pinnable-state.js
+++ b/resources/pinnable-state.js
@@ -1,0 +1,115 @@
+/**
+ * Persist Vector's "move to sidebar" (pinnable element) state on the static export.
+ *
+ * Vector keeps some pin states as client preferences, restored from a cookie by
+ * the inline <head> script (table of contents, appearance, limited width), and
+ * others as server-side-only user options (main menu, page tools). A static
+ * export is anonymous and pre-rendered once, so the server-side ones reset on
+ * every page load. This module fills the gap with mw.storage.
+ *
+ * It is driven by the declarative data attributes Vector already emits on each
+ * pinnable header (data-feature-name, data-pinnable-element-id,
+ * data-pinned-container-id, data-unpinned-container-id), so it covers any element
+ * following the same contract. Features Vector already persists client-side
+ * (their html class is "...-clientpref-...") are skipped, so we never
+ * double-manage a state Vector owns.
+ *
+ * Vector's initPinnableElement() runs at DOMContentLoaded and positions elements
+ * from the html feature class (features.isEnabled). We restore that class and the
+ * element location from storage; whichever of us runs first, the move is
+ * idempotent.
+ */
+(() => {
+	const FEATURE_PREFIX = "vector-feature-";
+	const STORAGE_PREFIX = "wikven:pinnable:";
+	const PINNED_HEADER_CLASS = "vector-pinnable-header-pinned";
+	const UNPINNED_HEADER_CLASS = "vector-pinnable-header-unpinned";
+	const html = document.documentElement;
+
+	const key = (feature) => STORAGE_PREFIX + feature;
+
+	// A feature Vector already persists client-side carries a
+	// "vector-feature-<name>-clientpref-*" html class; leave those to Vector.
+	const isClientPreference = (feature) =>
+		new RegExp(`(?:^| )${FEATURE_PREFIX}${feature}-clientpref-`).test(
+			html.className,
+		);
+
+	const setFeatureClass = (feature, pinned) => {
+		html.classList.remove(`${FEATURE_PREFIX}${feature}-enabled`);
+		html.classList.remove(`${FEATURE_PREFIX}${feature}-disabled`);
+		html.classList.add(
+			`${FEATURE_PREFIX}${feature}-${pinned ? "enabled" : "disabled"}`,
+		);
+	};
+
+	const moveElement = (header, pinned) => {
+		const element = document.getElementById(
+			header.getAttribute("data-pinnable-element-id"),
+		);
+		const target = document.getElementById(
+			header.getAttribute(
+				pinned ? "data-pinned-container-id" : "data-unpinned-container-id",
+			),
+		);
+		if (element && target && element.parentNode !== target) {
+			target.insertAdjacentElement("beforeend", element);
+		}
+	};
+
+	const restore = () => {
+		const headers = document.querySelectorAll(
+			".vector-pinnable-header[data-feature-name][data-pinnable-element-id]",
+		);
+		for (const header of headers) {
+			const feature = header.getAttribute("data-feature-name");
+			if (isClientPreference(feature)) {
+				continue;
+			}
+			const saved = mw.storage.get(key(feature));
+			if (saved !== "1" && saved !== "0") {
+				continue;
+			}
+			const pinned = saved === "1";
+			setFeatureClass(feature, pinned);
+			header.classList.toggle(PINNED_HEADER_CLASS, pinned);
+			header.classList.toggle(UNPINNED_HEADER_CLASS, !pinned);
+			moveElement(header, pinned);
+		}
+	};
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", restore);
+	} else {
+		restore();
+	}
+
+	// Record the user's choice when they click "move to sidebar" / "hide". Vector's
+	// own handler performs the live DOM move; we only persist the resulting state.
+	document.addEventListener("click", (event) => {
+		const target = event.target;
+		if (!(target instanceof Element)) {
+			return;
+		}
+		const button = target.closest(
+			".vector-pinnable-header-pin-button, .vector-pinnable-header-unpin-button",
+		);
+		if (!button) {
+			return;
+		}
+		const header = button.closest(".vector-pinnable-header[data-feature-name]");
+		if (!header) {
+			return;
+		}
+		const feature = header.getAttribute("data-feature-name");
+		if (isClientPreference(feature)) {
+			return;
+		}
+		mw.storage.set(
+			key(feature),
+			button.classList.contains("vector-pinnable-header-pin-button")
+				? "1"
+				: "0",
+		);
+	});
+})();


### PR DESCRIPTION
## Problem

Vector's "move to sidebar" pin state for the **main menu** and **page tools** is not preserved after navigating between pages on the static site.

Root cause is upstream, not a wikven regression. In Vector's `FeatureManager::getFeatureBodyClass()`:

- TOC / appearance / limited-width pins emit `-clientpref-` classes and are restored client-side from a cookie by the inline `<head>` script. These already work on the static site.
- **main-menu** and **page-tools** pins are explicitly marked `// Server side only feature flags.` and emit plain `enabled`/`disabled`. `pinnableElement.js` only persists them "for logged-in users" via the options API.

A static export is anonymous and pre-rendered once, so there is no per-user server render and no API. The toggle works visually but is lost on the next page. ("Treat the visitor as logged-in" can't work: the save path needs `action=options`, which a static host has no server for, and pages are baked once with the anonymous default so a saved server option could never be reflected.)

## Fix

Add a ResourceLoader module **`ext.Wikven.pinnableState`** (registered in `extension.json`, queued via `BeforePageDisplay` so wikven's static bundle includes and triggers it) that persists the state with **`mw.storage`**.

It is driven by the declarative data attributes Vector already emits on each pinnable header (`data-feature-name`, `data-pinnable-element-id`, `data-pinned-container-id`, `data-unpinned-container-id`) rather than hard-coded ids, so it covers any element following the same contract (both main-menu and page-tools, and future ones).

- Features Vector already persists client-side (their html class is `...-clientpref-...`) are **skipped**, so we never double-manage a state Vector owns. If Vector ever promotes these to client preferences, the module steps aside automatically.
- Vector's `initPinnableElement()` (at DOMContentLoaded) positions elements from the html feature class (`features.isEnabled()`); the module restores that class and the element location from `mw.storage`, and records the choice on a pin/unpin click. Whichever runs first, the move is idempotent.

## Verification

End-to-end against a real build (`docker build` + `docker run … wikven`), served over HTTP and driven in Chrome DevTools:

- **Restore:** click "move to sidebar" → `mw.storage` records `wikven:pinnable:main-menu-pinned = "1"`; navigating to another page restores the menu into the pinned container with the `…-enabled` class, with no further interaction. Works in both directions and for main-menu and page-tools independently. TOC (a client preference) is left to Vector.

- **Flicker, measured (not assumed):** instrumented the first-paint timeline with `requestAnimationFrame` sampling + `PerformanceObserver`.

  | | normal CPU | 20× CPU throttle |
  |---|---|---|
  | this module | move 37 ms < FCP 64 ms → no flicker | 1 painted frame pre-move (move +195 ms after FCP) |
  | inline `</body>` injection variant | no flicker | 1 painted frame pre-move (move +206 ms after FCP) |

  The element move is inherently bound to DOMContentLoaded on a pre-rendered page (the same constraint Vector's own client-preference features live with), so an end-of-body inline script has **no flicker advantage** over the module under load. The idiomatic ResourceLoader path was therefore chosen.

biome + mago clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)