### PR TITLE
fix: link images to their Commons page instead of a dead local File page

### DIFF
--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Wikven\Hooks;
 use Config;
 use FauxRequest;
 use Html;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
 use OutputPage;
@@ -40,6 +41,18 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 		if ($title->getInterwiki()) {
 			return;
 		}
+
+		// Images come from a foreign repo (Wikimedia Commons via InstantCommons),
+		// so the static export has no local File: page to link to. Point clicks at
+		// the file's real description page on Commons instead of a dead ./File:*.html.
+		if ($title->getNamespace() === NS_FILE) {
+			$file = MediaWikiServices::getInstance()->getRepoGroup()->findFile($title);
+			if ($file && !$file->isLocal()) {
+				$url = $file->getDescriptionUrl();
+				return;
+			}
+		}
+
 		global $wgWikvenEditUrl, $wgWikvenHistoryUrl;
 		$name = Title::makeName($title->getNamespace(), $title->getDBkey());
 		if (preg_match('/action=([^&]+)/', $query, $matches)) {


### PR DESCRIPTION
Closes #14.

## Problem

Images are served from Wikimedia Commons via InstantCommons, so the static export generates no local `File:` description page. MediaWiki still wraps each image in a link to the local file page, so clicking an image goes to a dead URL.

Before (in `dist/Images.html`):

```html
<a href="./File:Moscow_Metro_Volokolamskaya_asv2018-09.jpg.html" class="mw-file-description">
```

That `./File:*.html` does not exist on the static host → 404.

## Fix

In `Main::onGetLocalURL`, resolve `File`-namespace titles to their file and, when the file is foreign (Commons), use its real description URL instead of the local `./File:*.html` fallback:

```php
if ($title->getNamespace() === NS_FILE) {
    $file = MediaWikiServices::getInstance()->getRepoGroup()->findFile($title);
    if ($file && !$file->isLocal()) {
        $url = $file->getDescriptionUrl();
        return;
    }
}
```

After:

```html
<a href="https://commons.wikimedia.org/wiki/File:Moscow_Metro_Volokolamskaya_asv2018-09.jpg" class="mw-file-description">
```

## Verification

Full docker build + `dist` inspection:

- Every image anchor now points at `https://commons.wikimedia.org/wiki/File:<name>`.
- No `./File:*.html` links remain on any generated page.
- Local files (none today) keep the default path, so this only redirects foreign Commons files.

mago clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)