### PR TITLE
feat: enable bundled extensions safely, skipping ones not in the image

### DIFF
--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -59,10 +59,21 @@ if (file_exists('/workspace/src/.wikven.json')) {
 		unset($config['Skin']);
 	}
 
-	// Extensions
+	// Extensions. Only extensions bundled in this image can be enabled; a name
+	// that is not installed (a typo, or a third-party extension that is not yet
+	// supported) is skipped with a warning instead of aborting the whole build.
 	if (isset($config['Extensions'])) {
 		if (is_array($config['Extensions'])) {
-			wfLoadExtensions($config['Extensions']);
+			foreach ($config['Extensions'] as $extension) {
+				if (!is_string($extension)) {
+					continue;
+				}
+				if (is_file("$IP/extensions/$extension/extension.json")) {
+					wfLoadExtension($extension);
+				} else {
+					error_log("Wikven: skipping extension '$extension' (not bundled in this image)");
+				}
+			}
 		}
 		unset($config['Extensions']);
 	}


### PR DESCRIPTION
Lets a site enable any extension **bundled in the image** through the existing `.wikven.json` `Extensions` option, without the build aborting when a name is not installed.

## Background

`.wikven.json` `Extensions` already loaded extensions via `wfLoadExtensions`, and bundled ones work (the docs enable `SyntaxHighlight_GeSHi` + `ParserFunctions`). But `wfLoadExtensions` **fatals the whole build** on any name that is not installed, e.g. a typo or a third-party extension this image does not bundle (`TemplateStyles` is not in `mediawiki:1.43`):

```
extensions/TemplateStyles/extension.json does not exist!
```

## Change

Load each listed extension only when it is present (`$IP/extensions/<name>/extension.json`), and skip the rest with a warning:

```php
foreach ($config['Extensions'] as $extension) {
    if (!is_string($extension)) {
        continue;
    }
    if (is_file("$IP/extensions/$extension/extension.json")) {
        wfLoadExtension($extension);
    } else {
        error_log("Wikven: skipping extension '$extension' (not bundled in this image)");
    }
}
```

Bundled extensions become cleanly toggleable through the option, and listing a not-yet-supported third-party extension no longer breaks the build. Fetching third-party extensions (so e.g. TemplateStyles can be enabled) is left for a future change.

## Verification

Built with `Extensions: ["SyntaxHighlight_GeSHi", "ParserFunctions", "Cite", "TemplateStyles"]`:

- Build succeeds (exit 0); `TemplateStyles` is skipped with the warning instead of fataling.
- `Cite` works — `<ref>` renders `class="reference"` and a references list.
- `ParserFunctions` works — `{{#if: yes | … }}` resolves (no raw `{{#if}}` left).
- `SyntaxHighlight_GeSHi` still renders `mw-highlight`.

mago clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)