### PR TITLE
refactor: build the static site in a single MediaWiki boot

### DIFF
--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use CommentStoreComment;
+use ContentHandler;
+use Maintenance;
+use MediaWiki\Revision\SlotRecord;
+use RebuildFileCache;
+use RunJobs;
+use Title;
+use User;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/**
+ * Build the whole static site in a single MediaWiki boot.
+ *
+ * This replaces the long sequence of separate `php maintenance/run.php ...`
+ * invocations the build used to run (a fresh MediaWiki boot per step) with one
+ * process that runs every step as a child maintenance script. It keeps the
+ * orchestration in PHP instead of shell and avoids paying the bootstrap cost
+ * once per step.
+ *
+ * Steps, in order: set the main page, import the wikitext, run queued jobs,
+ * (re)build the file cache, then dump styles and scripts, rewrite them for the
+ * static host, store remote images locally, and give the files readable names.
+ */
+class Build extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription('Run the full wikven static-site build in a single process.');
+	}
+
+	public function execute() {
+		$ip = $GLOBALS['IP'];
+		$own = __DIR__;
+
+		$this->setMainPage();
+
+		$this->step(ImportWikitext::class, "$own/importWikitext.php");
+		$this->step(RunJobs::class, "$ip/maintenance/runJobs.php");
+		$this->step(RebuildFileCache::class, "$ip/maintenance/rebuildFileCache.php", ['overwrite' => true]);
+		$this->step(BuildStyles::class, "$own/buildStyles.php");
+		$this->step(BuildScripts::class, "$own/buildScripts.php");
+		$this->step(RewriteScripts::class, "$own/rewriteScripts.php");
+		$this->step(StoreImages::class, "$own/storeImages.php");
+		$this->step(Rename::class, "$own/rename.php");
+	}
+
+	/**
+	 * Run one build step as a child maintenance script.
+	 *
+	 * @param string $class
+	 * @param string $file
+	 * @param array $options Options to set on the child before it runs.
+	 */
+	private function step($class, $file, array $options = []) {
+		$child = $this->createChild($class, $file);
+		foreach ($options as $name => $value) {
+			$child->setOption($name, $value);
+		}
+		$child->execute();
+	}
+
+	/**
+	 * Point the wiki's main page at the imported "index" article.
+	 */
+	private function setMainPage() {
+		$title = Title::newFromText('MediaWiki:Mainpage');
+		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
+
+		$updater = $page->newPageUpdater($user);
+		$updater->setContent(SlotRecord::MAIN, ContentHandler::makeContent('index', $title));
+		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Set the main page'));
+	}
+}
+
+$maintClass = Build::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/run
+++ b/run
@@ -14,16 +14,5 @@ php maintenance/run.php install \
 
 echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
 
-echo 'index' | php maintenance/run.php edit 'MediaWiki:Mainpage'
-php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/importWikitext.php
-
-php maintenance/run.php runJobs
-php maintenance/run.php purgeList
-php maintenance/run.php rebuildFileCache --overwrite
-
-php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/buildStyles.php
-php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/buildScripts.php
-php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/rewriteScripts.php
-php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/storeImages.php
-php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/rename.php
+php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/build.php
 rm -rf /workspace/dist/history/


### PR DESCRIPTION
Closes #6.

## Problem

`run` orchestrated the build as ~11 separate `php maintenance/run.php …` invocations, each paying a full MediaWiki bootstrap, with the sequencing in bash.

## Change

Add `maintenance/build.php`, one orchestration maintenance script that runs every step as a **child maintenance script** (`createChild` + `execute`) in a single process:

1. set the main page (`MediaWiki:Mainpage` → `index`, via `PageUpdater`)
2. `ImportWikitext`
3. core `RunJobs`
4. core `RebuildFileCache` (`--overwrite`, set via `setOption`)
5. `BuildStyles`, `BuildScripts`, `RewriteScripts`, `StoreImages`, `Rename`

`run` shrinks to: install → append `WikvenSettings.php` → `build.php`. The orchestration is now PHP (consistent with the rest of the codebase) and the bootstrap cost is paid once instead of ~11 times.

Notes:
- The `MediaWiki:Mainpage` edit moved into `build.php`.
- The dropped `purgeList` step was a no-op (`Purging 0 urls` — nothing was piped to it).

## Verification

Generated `dist` with the previous multi-boot `run`, then with the new single-boot build, and diffed them:

- **The article HTML, every CSS/JS file, and all images are byte-identical.**
- The only differences are non-deterministic build metadata that varies between *any* two builds — request ids, cache timestamps, parse profiling, and the installer's unused `Main_Page` footer time — plus three icon-module version hashes in `startup-static.js`. Those hashes are inert here because the module store is disabled (`$wgResourceLoaderStorageEnabled = false`) and modules are force-loaded from the static bundle.
- Browser smoke test of the single-boot output: page renders, image loads, Vector icons render, no broken images.

mago clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)