### PR TITLE
docs: copy-edit English and fix stale Skins config examples

### DIFF
--- a/docs/Editing sidebar.wikitext
+++ b/docs/Editing sidebar.wikitext
@@ -1,4 +1,4 @@
-The sidebar can be configured by the same way on MediaWiki, editing <code>MediaWiki:Sidebar</code>.
+The sidebar can be configured the same way as on MediaWiki, by editing <code>MediaWiki:Sidebar</code>.
 
 {{prevnext|Images}}
 

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -1,13 +1,13 @@
-This page, we build a basic [[mw:en:"Hello, World!" program|Hello World]] page with {{wikven}}.
-{{note|This page assumes unix-like OS.}}
+On this page, we build a basic [[mw:en:"Hello, World!" program|Hello World]] page with {{wikven}}.
+{{note|This page assumes a unix-like OS.}}
 
-{{wikven}} is formed of two parts: a script and a MediaWiki extension. To simplify the whole building
-process, a docker image is provided and this guide will show the usage.
+{{wikven}} consists of two parts: a script and a MediaWiki extension. To simplify the whole build
+process, a docker image is provided, and this guide shows how to use it.
 
 ; Requirement
 :* [https://www.docker.com/ Docker]
 
-If Docker is ready, you could go to the next step.
+If Docker is ready, you can move on to the next step.
 
 ----
 
@@ -18,14 +18,14 @@ Create two directories, <code>src</code> and
 $ mkdir src dist
 </syntaxhighlight>
 
-Then create a wikitext file. Any file ends with <code>.wikitext</code> is considered as a wiki
+Then create a wikitext file. Any file that ends with <code>.wikitext</code> is treated as a wiki
 article by {{wikven}}.
 
 <syntaxhighlight lang="shell-session">
 $ echo 'Hello, World!' > src/index.wikitext
 </syntaxhighlight>
 
-And run Docker with [https://docs.docker.com/storage/volumes/ volume mounting]:
+Then run Docker with [https://docs.docker.com/storage/volumes/ volume mounting]:
 
 <syntaxhighlight lang="shell-session">
 $ docker run \
@@ -35,11 +35,11 @@ $ docker run \
   ghcr.io/chaotic-ground/wikven
 </syntaxhighlight>
 
-Open <code>"$(pwd)"/dist/index.html</code> on your browser.
+Open <code>"$(pwd)"/dist/index.html</code> in your browser.
 
 == Setting the title of the site ==
 
-For configurations, you must create [[wikven.yaml|<code>.wikven.yaml</code>]] file in your
+For configuration, you must create a [[wikven.yaml|<code>.wikven.yaml</code>]] file in your
 <code>src</code> directory.
 
 <syntaxhighlight lang="shell-session">

--- a/docs/Images.wikitext
+++ b/docs/Images.wikitext
@@ -1,5 +1,5 @@
 [[File:Moscow Metro Volokolamskaya asv2018-09.jpg|thumb|Volokolamskaya metro station in Moscow, Russia.]]
 
-You can embed images on [[commons:Main Page|Wikimedia Commons]]. Visit {{ml|InstantCommons}} for details.
+You can embed images from [[commons:Main Page|Wikimedia Commons]]. See {{ml|InstantCommons}} for details.
 
 {{prevnext|Skins}}

--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -1,29 +1,25 @@
 You can choose {{ml|Bundled extensions|bundled skins}} in [[wikven.yaml|.wikven.yaml]].
 
-== Availrable skins ==
+== Available skins ==
 
 * {{ml|Skin:Vector|Vector}} (default)
 * {{ml|Skin:Timeless|Timeless}}
 * {{ml|Skin:Monobook|Monobook}}
 
-== Configuration skin ==
+== Configuring the skin ==
 
-Changing skin is possible by set <code>Skin</code>.
+You can change the skin by setting <code>skins</code>. The first skin in the list is used as the default.
 
-<syntaxhighlight lang="json">
-{
-  "Skin": "Timeless"
-}
+<syntaxhighlight lang="yaml">
+skins:
+  - Timeless
 </syntaxhighlight>
 
-== Skin-specific configurations ==
+== Skin-specific configuration ==
 
-You can use <code>wg</code> map.
+Use the <code>config</code> map.
 
-<syntaxhighlight lang="json">
-{
-  "wg": {
-    "VectorDefaultSkinVersion": "1"
-  }
-}
+<syntaxhighlight lang="yaml">
+config:
+  VectorDefaultSkinVersion: "1"
 </syntaxhighlight>

--- a/docs/Template:ml.wikitext
+++ b/docs/Template:ml.wikitext
@@ -1,5 +1,5 @@
 <onlyinclude>[[mw:Special:MyLanguage/{{{1|}}}|{{{2|{{{1|}}}}}}]]</onlyinclude><!--
-Links on the article on MediaWikiWiki(https://www.mediawiki.org/).
+Links to an article on mediawiki.org (https://www.mediawiki.org/).
 
 Usage:
 

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -10,7 +10,7 @@ With {{wikven}}, you can use the following features of MediaWiki.
 * [[Images|Using images on Wikimedia Commons]]
 * {{ml|Bundled extensions and skins}}
 
-== Unsuporretd features ==
+== Unsupported features ==
 
 * Search
 * All special pages
@@ -19,11 +19,11 @@ With {{wikven}}, you can use the following features of MediaWiki.
 
 === Planned features ===
 
-The follwing features are currently not supported but planned to be added in the future.
+The following features are currently not supported, but are planned for the future.
 
-* JavaScript.
-* Local images.
-* Support for thrid-party skins/extensions.
+* JavaScript
+* Local images
+* Support for third-party skins/extensions
 
 {{prevnext|Getting Started}}
 {{DISPLAYTITLE:Wikven}}


### PR DESCRIPTION
## What

A copy-editing pass over the README and the wiki documentation pages.

## Changes

- **Typos:** `Unsuporretd` → `Unsupported`, `follwing` → `following`, `thrid-party` → `third-party`, `Availrable` → `Available`.
- **Grammar / phrasing:** missing articles, "considered as" → "treated as", "on your browser" → "in your browser", "by the same way on MediaWiki" → "the same way as on MediaWiki", "is formed of two parts" → "consists of two parts", and similar small fixes on *Getting Started*, *Editing sidebar*, and *Images*.
- **Correctness:** the *Skins* page still showed the old JSON config with `Skin` / `wg` keys. Updated those snippets to the `.wikven.yaml` `skins` / `config` form (PR #28 changed the format but missed this page's body).

## Verification

Built the docker image and confirmed all edited pages render, the corrected headings/words appear, and no stale `"Skin"` / `"wg"` JSON keys remain in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
