### PR TITLE
ci: spell-check the repository with typos

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -60,5 +60,4 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      # Spell-check the whole repository (typos checks identifiers conservatively).
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -53,3 +53,12 @@ jobs:
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      # Spell-check the whole repository (typos checks identifiers conservatively).
+      - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2


### PR DESCRIPTION
## What

Adds a `typos` ([crate-ci/typos](https://github.com/crate-ci/typos)) job to the **Lint** workflow that spell-checks the **whole repository**.

```yaml
typos:
  steps:
    - uses: actions/checkout@... # v6.0.2
    - uses: crate-ci/typos@... # v1.47.2
```

## Notes

- **Scope:** the entire repo. `typos` checks code identifiers conservatively, so source files are safe to scan. Verified locally with v1.47.2: the repo is currently typo-clean (exit 0) with **no false positives**, so no `typos.toml` allowlist is needed yet. Project names (`Wikven`, `MediaWikiWiki`, `Volokolamskaya`, `GeSHi`, ...) are not flagged.
- **Limitation:** `typos` only flags known misspellings from its dictionary, so it complements rather than replaces manual review (e.g. it does not catch `Unsuporretd`/`Availrable`). If you want stricter coverage later, a custom dictionary in `typos.toml` is the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
