### PR TITLE
feat(config): read .wikven.json as a fallback to .wikven.yaml

### DIFF
--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -37,13 +37,28 @@ $wgVectorStickyHeader = ['logged_out' => true];
 $wgVectorLanguageInHeader = $wgVectorStickyHeader;
 $wgVectorResponsive = true;
 
-// Read configurations from .wikven.yaml, the same format MediaWiki's own
-// settings system (MW_CONFIG_FILE) accepts. YamlFormat prefers the PECL yaml
-// extension and falls back to the bundled symfony/yaml, so no extra dependency
-// is required.
+// Read configurations from .wikven.yaml or .wikven.json, the same formats
+// MediaWiki's own settings system (MW_CONFIG_FILE) accepts. YAML is the primary
+// format; .wikven.json is read only when no .wikven.yaml is present. (YAML is a
+// superset of JSON, so JSON syntax is also valid inside a .wikven.yaml file.)
+// YamlFormat prefers the PECL yaml extension and falls back to the bundled
+// symfony/yaml, so no extra dependency is required.
+$wikvenConfigFile = null;
 if (file_exists('/workspace/src/.wikven.yaml')) {
-	$text = file_get_contents('/workspace/src/.wikven.yaml');
-	$config = ( new MediaWiki\Settings\Source\Format\YamlFormat() )->decode($text);
+	$wikvenConfigFile = '/workspace/src/.wikven.yaml';
+	if (file_exists('/workspace/src/.wikven.json')) {
+		error_log('Wikven: both .wikven.yaml and .wikven.json exist; using .wikven.yaml and ignoring .wikven.json');
+	}
+} elseif (file_exists('/workspace/src/.wikven.json')) {
+	$wikvenConfigFile = '/workspace/src/.wikven.json';
+}
+
+if ($wikvenConfigFile !== null) {
+	$text = file_get_contents($wikvenConfigFile);
+	$format = str_ends_with($wikvenConfigFile, '.json')
+		? new MediaWiki\Settings\Source\Format\JsonFormat()
+		: new MediaWiki\Settings\Source\Format\YamlFormat();
+	$config = $format->decode($text);
 
 	// Skins. Register each named skin and use the first as the default. Only
 	// skins bundled in this image can be enabled; an unknown name is skipped

--- a/docs/wikven.yaml.wikitext
+++ b/docs/wikven.yaml.wikitext
@@ -2,6 +2,8 @@ __TOC__
 
 The configuration file follows the same shape as {{ml|Manual:YAML settings file format|MediaWiki's own YAML settings format}}: a top-level <code>extensions</code> list, a <code>skins</code> list, and a <code>config</code> map.
 
+The file may also be written as <code>.wikven.json</code> with the same structure. When both files are present, <code>.wikven.yaml</code> takes precedence and <code>.wikven.json</code> is ignored.
+
 <syntaxhighlight lang="yaml">
 extensions:
   - SyntaxHighlight_GeSHi


### PR DESCRIPTION
## What

Accepts a `.wikven.json` configuration file in addition to `.wikven.yaml`, since MediaWiki's settings system (`MW_CONFIG_FILE`) supports both formats.

## Precedence (YAML preferred)

- `.wikven.yaml` is the primary format.
- `.wikven.json` is read **only when no `.wikven.yaml` is present**.
- When **both** exist, `.wikven.yaml` wins and `.wikven.json` is ignored, with a warning logged. The two files are never merged.

JSON is parsed with MediaWiki's `JsonFormat`, YAML with `YamlFormat`, chosen by file extension.

## Why a separate `.json` extension is mostly a convenience

YAML 1.2 is a superset of JSON, so JSON syntax already parses inside a `.wikven.yaml` file. The `.json` extension is supported mainly for familiarity and discoverability.

## Verification

Built the image and tested three sources:

| Source | Result |
| --- | --- |
| `.wikven.json` only | config applied (sitename, footer URL, skin) ✅ |
| both `.yaml` + `.json` | `.yaml` wins, warning logged ✅ |
| `.wikven.yaml` only | unchanged behavior ✅ |

The config reference page documents the `.json` option and the precedence rule. `mago` and `typos` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
