### PR TITLE
ci: manage repository settings with repo-settings-as-code

### DIFF
--- a/.github/workflows/tf.yaml
+++ b/.github/workflows/tf.yaml
@@ -1,0 +1,32 @@
+name: Tofu
+
+on:
+  pull_request:
+    paths:
+      - ".tf/**"
+      - .github/workflows/tf.yaml
+  push:
+    branches:
+      - main
+    paths:
+      - ".tf/**"
+      - .github/workflows/tf.yaml
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: lens0021/repo-settings-as-code@382f2d2dc79977772e993f66a1fd801bfc67e8c3 # v2.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /vendor/
 /composer.lock
 /dist/
+
+# OpenTofu / Terraform
+/.tf/.terraform/
+/.tf/terraform.tfstate
+/.tf/terraform.tfstate.backup

--- a/.tf/.terraform.lock.hcl
+++ b/.tf/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.11.1"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:Hqvebe3Zc19DxRCHHLIByBvxCm+WJqGyAyYCbJDuHGE=",
+    "zh:0a5262b033a30d8a77ebf844dc3afd7e726d5f53ac1c9d4072cf9157820d1f73",
+    "zh:437236181326f92d1a7c56985b2ac3223efd73f75c528323b90f4b7d1b781090",
+    "zh:49a12c14d1d3a143a124ba81f15fbf18714af90752c993698c76e84fa85da004",
+    "zh:61eaf17b559a26ca14deb597375a6678d054d739e8b81c586ef1d0391c307916",
+    "zh:7f3f1e2c36f4787ca9a5aeb5317b8c3f6cc652368d1f8f00fb80f404109d4db1",
+    "zh:85a232f2e96e5adafa2676f38a96b8cc074e96f715caf6ee1d169431174897d2",
+    "zh:979d005af2a9003d887413195948c899e9f5aba4a79cce1eed40f3ba50301af1",
+    "zh:b8c8cd3254504d2184d2b2233ad41b5fdfda91a36fc864926cbc5c7eee1bfea3",
+    "zh:d00959e62930fb75d2b97c1d66ab0143120541d5a1b3f26d3551f24cb0361f83",
+    "zh:d0b544eed171c7563387fe87f0af3d238bb3804798159b4d0453c97927237daf",
+    "zh:ecfa19b1219aa55b1ece98d8cff5b1494dc0387329c8ae0d8f762ec3871fb75d",
+    "zh:f2c99825f38c92ac599ad36b9d093ea0c0d790fd0c02e861789e14735a605f86",
+    "zh:f33b5abe14ad5fb9978da5dbd3bc6989f69766150d4b30ed283a2c281871eda3",
+    "zh:f6c2fe9dd958c554170dc0c35ca41b60fcc6253304cde0b9941c5c872b18ac54",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/.tf/main.tf
+++ b/.tf/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.0"
+
+  backend "local" {}
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = "chaotic-ground"
+}

--- a/.tf/repository.tf
+++ b/.tf/repository.tf
@@ -1,0 +1,49 @@
+import {
+  id = "wikven"
+  to = github_repository.this
+}
+resource "github_repository" "this" {
+  allow_auto_merge            = true
+  allow_merge_commit          = true
+  allow_rebase_merge          = true
+  allow_squash_merge          = true
+  allow_update_branch         = false
+  archived                    = false
+  archive_on_destroy          = true
+  auto_init                   = false
+  delete_branch_on_merge      = true
+  description                 = "A static web site generator using MediaWiki."
+  has_discussions             = false
+  has_issues                  = true
+  has_projects                = false
+  has_wiki                    = false
+  homepage_url                = "https://chaotic-ground.github.io/wikven/"
+  name                        = "wikven"
+  squash_merge_commit_message = "COMMIT_MESSAGES"
+  squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
+  topics                      = ["docker-image", "mediawiki", "static-site-generator", "wikitext"]
+  visibility                  = "public"
+  vulnerability_alerts        = var.github_actions ? null : true
+  web_commit_signoff_required = false
+
+  dynamic "security_and_analysis" {
+    for_each = var.github_actions ? [] : [true]
+    content {
+      secret_scanning {
+        status = "enabled"
+      }
+      secret_scanning_push_protection {
+        status = "enabled"
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Cannot be imported
+      archive_on_destroy,
+      # Deprecated
+      ignore_vulnerability_alerts_during_read,
+    ]
+  }
+}

--- a/.tf/repository.tf
+++ b/.tf/repository.tf
@@ -14,6 +14,7 @@ resource "github_repository" "this" {
   delete_branch_on_merge      = true
   description                 = "A static web site generator using MediaWiki."
   has_discussions             = false
+  has_downloads               = true
   has_issues                  = true
   has_projects                = false
   has_wiki                    = false
@@ -25,6 +26,12 @@ resource "github_repository" "this" {
   visibility                  = "public"
   vulnerability_alerts        = var.github_actions ? null : true
   web_commit_signoff_required = false
+
+  # GitHub Pages publishes the site to chaotic-ground.github.io/wikven via the
+  # deploy-docs workflow. Declare it so the configuration does not remove it.
+  pages {
+    build_type = "workflow"
+  }
 
   dynamic "security_and_analysis" {
     for_each = var.github_actions ? [] : [true]

--- a/.tf/repository.tf
+++ b/.tf/repository.tf
@@ -5,9 +5,9 @@ import {
 resource "github_repository" "this" {
   allow_auto_merge            = true
   allow_merge_commit          = true
-  allow_rebase_merge          = true
-  allow_squash_merge          = true
-  allow_update_branch         = false
+  allow_rebase_merge          = false
+  allow_squash_merge          = false
+  allow_update_branch         = true
   archived                    = false
   archive_on_destroy          = true
   auto_init                   = false
@@ -18,9 +18,9 @@ resource "github_repository" "this" {
   has_projects                = false
   has_wiki                    = false
   homepage_url                = "https://chaotic-ground.github.io/wikven/"
+  merge_commit_message        = "PR_BODY"
+  merge_commit_title          = "PR_TITLE"
   name                        = "wikven"
-  squash_merge_commit_message = "COMMIT_MESSAGES"
-  squash_merge_commit_title   = "COMMIT_OR_PR_TITLE"
   topics                      = ["docker-image", "mediawiki", "static-site-generator", "wikitext"]
   visibility                  = "public"
   vulnerability_alerts        = var.github_actions ? null : true

--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -1,0 +1,57 @@
+resource "github_repository_ruleset" "default" {
+  name        = "default"
+  repository  = github_repository.this.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    # Protect the default branch: block deletion and force-pushes, and require a
+    # pull request for every change (so direct pushes to main are not allowed).
+    deletion         = true
+    non_fast_forward = true
+    update           = false
+
+    # Merge commits are the only allowed merge method, so a linear history must
+    # not be required (requiring it would forbid merge commits).
+    required_linear_history = false
+    required_signatures     = false
+
+    pull_request {
+      dismiss_stale_reviews_on_push     = false
+      require_code_owner_review         = false
+      require_last_push_approval        = false
+      required_approving_review_count   = 0
+      required_review_thread_resolution = false
+    }
+
+    # Require the checks from the Lint workflow (.github/workflows/lint.yaml) to
+    # pass before a pull request can be merged. integration_id 15368 is the
+    # GitHub Actions app, so only its check runs satisfy these.
+    required_status_checks {
+      do_not_enforce_on_create             = false
+      strict_required_status_checks_policy = false
+
+      dynamic "required_check" {
+        for_each = [
+          "biome",
+          "mago",
+          "rumdl",
+          "taplo",
+          "typos",
+          "zizmor",
+        ]
+        content {
+          context        = required_check.value
+          integration_id = 15368
+        }
+      }
+    }
+  }
+}

--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -4,6 +4,21 @@ resource "github_repository_ruleset" "default" {
   target      = "branch"
   enforcement = "active"
 
+  # Let repository admins and the chaotic-ground/publishers team bypass the
+  # rules. Gated on github_actions because the Actions GITHUB_TOKEN cannot
+  # resolve the team actor; bypass actors are managed only on local PAT runs.
+  dynamic "bypass_actors" {
+    for_each = var.github_actions ? [] : [
+      { actor_id = 5, actor_type = "RepositoryRole" }, # Repository admin
+      { actor_id = 17810468, actor_type = "Team" },    # chaotic-ground/publishers
+    ]
+    content {
+      actor_id    = bypass_actors.value.actor_id
+      actor_type  = bypass_actors.value.actor_type
+      bypass_mode = "always"
+    }
+  }
+
   conditions {
     ref_name {
       include = ["~DEFAULT_BRANCH"]
@@ -31,9 +46,10 @@ resource "github_repository_ruleset" "default" {
       required_review_thread_resolution = false
     }
 
-    # Require the checks from the Lint workflow (.github/workflows/lint.yaml) to
-    # pass before a pull request can be merged. integration_id 15368 is the
-    # GitHub Actions app, so only its check runs satisfy these.
+    # Require status checks to pass before a pull request can be merged: the
+    # Lint workflow jobs (.github/workflows/lint.yaml) and the semantic pull
+    # request title check. integration_id 15368 is the GitHub Actions app, so
+    # only its check runs satisfy these.
     required_status_checks {
       do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false
@@ -43,6 +59,7 @@ resource "github_repository_ruleset" "default" {
           "biome",
           "mago",
           "rumdl",
+          "semantic-pull-request",
           "taplo",
           "typos",
           "zizmor",

--- a/.tf/variable.tf
+++ b/.tf/variable.tf
@@ -1,0 +1,4 @@
+variable "github_actions" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
## What

Adopts [`lens0021/repo-settings-as-code`](https://github.com/lens0021/repo-settings-as-code) to manage this repository's GitHub settings as code with OpenTofu, modeled on the action's own dogfood setup, and uses it to set a merge-only policy and branch protection.

## Files

- **`.tf/repository.tf`** — `github_repository` with an `import` block (`id = "wikven"`) so the existing repo is adopted into state.
- **`.tf/ruleset.tf`** — a `github_repository_ruleset` protecting the default branch.
- **`.tf/main.tf`** / **`variable.tf`** / **`.terraform.lock.hcl`** — provider (`integrations/github`, owner `chaotic-ground`), local backend, pinned `~> 6.0`.
- **`.github/workflows/tf.yaml`** — runs the action: `plan` + comment on PRs, `plan` + drift issue on push to `main` / manual dispatch.
- **`.gitignore`** — ignores Tofu state and `.terraform/`.

## Deliberate settings changes (will show in the plan)

**Merge strategy → merge commits only**
- `allow_squash_merge = false`, `allow_rebase_merge = false` (merge commit stays on).
- `merge_commit_title = "PR_TITLE"`, `merge_commit_message = "PR_BODY"` (suits Conventional Commits + release-please).
- The `squash_merge_commit_*` fields are dropped (provider defaults match current values, so drift-free).
- `allow_update_branch = true`.

**Branch protection (`ruleset.tf`) on the default branch**
- Require a pull request for every change (no direct pushes to `main`); block branch deletion and force-pushes.
- Required status checks: **biome, mago, rumdl, semantic-pull-request, taplo, typos, zizmor**.
- Linear history is intentionally **not** required (it would forbid merge commits). No required approvals (0), so a solo maintainer can still merge once checks pass.
- **Bypass actors:** repository admins (`RepositoryRole` 5) and the `chaotic-ground/publishers` team (`17810468`). Gated on `github_actions` so they are managed only on local PAT runs (the Actions `GITHUB_TOKEN` cannot resolve the team actor).

## How to apply

CI only **plans / detects drift** (`GITHUB_TOKEN`). To enforce, run locally with a PAT that has admin on the repo:

```
cd .tf && tofu init && tofu plan   # then `tofu apply`
```

Because the config mirrors current settings except for the deliberate changes above, the plan should show only those changes (plus the import).

## Verification

`tofu init` + `tofu validate` resolve cleanly from the registry (provider `6.11.1`), and `tofu fmt`, `typos`, and `zizmor` all pass.

> Note on `actor_id`: GitHub doesn't publish the `RepositoryRole` ID table; `5` is the admin role under the standard `1=read … 5=admin` ordering. If a `tofu apply` rejects it, that's the value to double-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
