### PR TITLE
fix(repo): stop the OpenTofu ruleset from re-planning on every CI run

### DIFF
--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -9,19 +9,20 @@ resource "github_repository_ruleset" "default" {
   enforcement = "active"
 
   # Let repository admins and the chaotic-ground/publishers team bypass the
-  # rules. Declared unconditionally (not gated on github_actions): the stateless
-  # CI run re-imports the ruleset every time, so the config must match reality
-  # or it reports drift forever. Rulesets are readable with plain repo read, so
-  # the Actions GITHUB_TOKEN can still refresh them.
-  bypass_actors {
-    actor_id    = 5 # Repository admin
-    actor_type  = "RepositoryRole"
-    bypass_mode = "always"
-  }
-  bypass_actors {
-    actor_id    = 17810468 # chaotic-ground/publishers
-    actor_type  = "Team"
-    bypass_mode = "always"
+  # rules. Gated on github_actions: the Actions GITHUB_TOKEN cannot read a
+  # ruleset's bypass actors (they are admin-only), so in CI it sees an empty
+  # set. Declaring them only on local PAT runs keeps both the stateless CI plan
+  # (empty == empty) and local runs (two == two) free of drift.
+  dynamic "bypass_actors" {
+    for_each = var.github_actions ? [] : [
+      { actor_id = 5, actor_type = "RepositoryRole" }, # Repository admin
+      { actor_id = 17810468, actor_type = "Team" },    # chaotic-ground/publishers
+    ]
+    content {
+      actor_id    = bypass_actors.value.actor_id
+      actor_type  = bypass_actors.value.actor_type
+      bypass_mode = "always"
+    }
   }
 
   conditions {

--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -1,3 +1,7 @@
+import {
+  id = "wikven:17638220"
+  to = github_repository_ruleset.default
+}
 resource "github_repository_ruleset" "default" {
   name        = "default"
   repository  = github_repository.this.name
@@ -5,18 +9,19 @@ resource "github_repository_ruleset" "default" {
   enforcement = "active"
 
   # Let repository admins and the chaotic-ground/publishers team bypass the
-  # rules. Gated on github_actions because the Actions GITHUB_TOKEN cannot
-  # resolve the team actor; bypass actors are managed only on local PAT runs.
-  dynamic "bypass_actors" {
-    for_each = var.github_actions ? [] : [
-      { actor_id = 5, actor_type = "RepositoryRole" }, # Repository admin
-      { actor_id = 17810468, actor_type = "Team" },    # chaotic-ground/publishers
-    ]
-    content {
-      actor_id    = bypass_actors.value.actor_id
-      actor_type  = bypass_actors.value.actor_type
-      bypass_mode = "always"
-    }
+  # rules. Declared unconditionally (not gated on github_actions): the stateless
+  # CI run re-imports the ruleset every time, so the config must match reality
+  # or it reports drift forever. Rulesets are readable with plain repo read, so
+  # the Actions GITHUB_TOKEN can still refresh them.
+  bypass_actors {
+    actor_id    = 5 # Repository admin
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+  bypass_actors {
+    actor_id    = 17810468 # chaotic-ground/publishers
+    actor_type  = "Team"
+    bypass_mode = "always"
   }
 
   conditions {


### PR DESCRIPTION
## What

Fixes the recurring **"OpenTofu: apply needed"** drift issue (#35) that the Tofu workflow opened on every push to `main`.

## Why it was firing

The Tofu CI runs are **stateless** (state is gitignored), so every run re-imports the configured resources and compares to reality. The ruleset had **no `import` block**, so with empty state CI planned to *create* it (`1 to add`) on every run, even though it already exists. The live repo was correct — this was purely a drift-detection artifact.

## Fix

- Add an `import` block for the ruleset (`id = "wikven:17638220"`), mirroring the repository, so CI imports it instead of planning to create it.
- Keep `bypass_actors` **gated on `github_actions`**. The Actions `GITHUB_TOKEN` cannot read a ruleset's bypass actors (they are admin-only), so in CI it sees an empty set: the gated (empty) config matches the token's view, while local PAT runs declare the two actors and match reality. (An initial attempt in this PR to declare them unconditionally was reverted — it made CI plan to *add* them on every run, since the token reads them as empty.)

Live settings are unchanged (they already match), so no re-apply is needed; this only fixes drift detection.

## Verification

The PR's own Tofu plan, run with the real `GITHUB_TOKEN`, reported:

```
No changes. Your infrastructure matches the configuration.
```

So on `main` the next run is clean and the drift issue does not reopen.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
