### PR TITLE
feat: run site JavaScript and gadgets

### DIFF
--- a/docs/JavaScript.wikitext
+++ b/docs/JavaScript.wikitext
@@ -1,0 +1,24 @@
+{{wikven}} runs the wiki's own JavaScript in the static export, so site scripts and gadgets work without a live server.
+
+== MediaWiki:Common.js ==
+
+Site-wide JavaScript lives in <code>MediaWiki:Common.js</code>, just like on a regular wiki. Create a <code>MediaWiki:Common.js.wikitext</code> file in your source directory and it runs on every page. The skin's <code>MediaWiki:Vector.js</code> (and so on) works the same way.
+
+== Gadgets ==
+
+To use {{ml|Extension:Gadgets|gadgets}}, enable the bundled Gadgets extension in [[wikven.yaml|.wikven.yaml]]:
+
+<syntaxhighlight lang="yaml">
+extensions:
+  - Gadgets
+</syntaxhighlight>
+
+List your gadgets in <code>MediaWiki:Gadgets-definition.wikitext</code>, and put each gadget's code in <code>MediaWiki:Gadget-<name>.js.wikitext</code>:
+
+<syntaxhighlight lang="wikitext">
+* MyGadget[ResourceLoader|default]|MyGadget.js
+</syntaxhighlight>
+
+Only gadgets marked <code>default</code> are loaded: a static site has no logged-in readers to turn other gadgets on. A gadget's own CSS (in the same module) is included, but standalone styles-only gadgets are not yet covered.
+
+{{DISPLAYTITLE:JavaScript}}

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -5,6 +5,7 @@
 ** Editing sidebar|Editing sidebar
 ** Images|Images
 ** Skins|Skins
+** JavaScript|JavaScript
 * References
 ** wikven.yaml|.wikven.yaml
 *

--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -23,3 +23,5 @@ Use the <code>config</code> map.
 config:
   VectorDefaultSkinVersion: "1"
 </syntaxhighlight>
+
+{{prevnext|JavaScript}}

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -8,6 +8,7 @@ With {{wikven}}, you can use the following features of MediaWiki.
 * {{ml|Wikitext}}
 * {{ml|Help:Templates|Templates}}
 * [[Images|Images]] from Wikimedia Commons or local files
+* [[JavaScript]] (MediaWiki:Common.js and gadgets)
 * {{ml|Bundled extensions and skins}}
 
 == Unsupported features ==
@@ -21,7 +22,6 @@ With {{wikven}}, you can use the following features of MediaWiki.
 
 The following features are currently not supported, but are planned for the future.
 
-* JavaScript
 * Support for third-party skins/extensions
 
 {{prevnext|Getting Started}}

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -32,10 +32,10 @@ require_once "$IP/maintenance/Maintenance.php";
  */
 class BuildScripts extends Maintenance {
 	/** Module groups that are never emitted statically (mirrors Main/buildStyles). */
-	private const SKIP_GROUPS = ['site', 'noscript', 'private', 'user'];
+	private const SKIP_GROUPS = ['noscript', 'private', 'user'];
 
-	/** Modules that cannot be built outside a real web request. */
-	private const SKIP_MODULES = ['site', 'site.styles', 'user', 'user.styles', 'user.options'];
+	/** Per-user / styles-only modules that have no place in the static JS bundle. */
+	private const SKIP_MODULES = ['site.styles', 'user', 'user.styles', 'user.options'];
 
 	public function __construct() {
 		parent::__construct();
@@ -52,10 +52,22 @@ class BuildScripts extends Maintenance {
 		}
 
 		$rl = MediaWikiServices::getInstance()->getResourceLoader();
+		// Gadgets registers its modules into the ResourceLoader at boot, before the
+		// single build process has imported the gadget definitions, so the modules
+		// are missing here. Re-register them from the (now populated) gadget repo.
+		$this->registerGadgetModules($rl);
 		MediaWikiServices::getInstance()->getDBLoadBalancerFactory()->disableChronologyProtection();
 
 		// 1. Discover the modules the rendered pages actually queue.
 		$seeds = $this->collectPageModules($htmlDir);
+		// The site module (MediaWiki:Common.js plus the skin's JS) is pulled in by
+		// the startup module on a live wiki, so it never appears in a page's module
+		// queue. Seed it explicitly so that site JS runs on the static pages too.
+		$seeds[] = 'site';
+		// Likewise the gadgets enabled for every reader: the Gadgets hook adds them
+		// at request time, which the static render does not reproduce, so seed them
+		// so default gadgets are bundled too.
+		$seeds = array_merge($seeds, $this->defaultGadgetModules());
 		// 2. Expand to the full dependency closure, plus the implicit base modules.
 		$closure = $this->resolveClosure($rl, $seeds, $wgLanguageCode, $wgDefaultSkin);
 
@@ -80,6 +92,51 @@ class BuildScripts extends Maintenance {
 		);
 
 		$this->output('Wrote startup-static.js and modules-static.js (' . count($closure) . " modules)\n");
+	}
+
+	/**
+	 * Register every gadget's ResourceLoader module on the given loader, mirroring
+	 * the Gadgets extension's own registration. No-op without the extension.
+	 *
+	 * @param ResourceLoader $rl
+	 */
+	private function registerGadgetModules(ResourceLoader $rl) {
+		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
+		if (!class_exists($repoClass)) {
+			return;
+		}
+		$repo = $repoClass::singleton();
+		foreach ($repo->getGadgetIds() as $id) {
+			$name = \MediaWiki\Extension\Gadgets\Gadget::getModuleName($id);
+			if (!$rl->isModuleRegistered($name)) {
+				$rl->register($name, [
+					'class' => \MediaWiki\Extension\Gadgets\GadgetResourceLoaderModule::class,
+					'id' => $id
+				]);
+			}
+		}
+	}
+
+	/**
+	 * @return string[] Module names of the gadgets enabled for every reader (so
+	 *   they can be bundled like the page's own modules), or an empty array when
+	 *   the Gadgets extension is not loaded.
+	 */
+	private function defaultGadgetModules() {
+		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
+		if (!class_exists($repoClass)) {
+			return [];
+		}
+		$modules = [];
+		$repo = $repoClass::singleton();
+		foreach ($repo->getGadgetIds() as $id) {
+			$gadget = $repo->getGadget($id);
+			// Styles-only gadgets belong in the CSS dump, not the JS bundle.
+			if ($gadget->isOnByDefault() && $gadget->hasModule() && $gadget->getType() !== 'styles') {
+				$modules[] = \MediaWiki\Extension\Gadgets\Gadget::getModuleName($id);
+			}
+		}
+		return $modules;
 	}
 
 	/**

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -46,15 +46,18 @@ class ImportWikitext extends Maintenance {
 
 			$this->output("Saving... $title");
 
-			// A "File:Name.ext.wikitext" file describes an uploaded image. The
-			// upload already created the File: page with a default description, so
-			// save the sidecar as the current revision to replace it; an old
-			// revision (below) would land behind the upload and be ignored.
-			if ($title->getNamespace() === NS_FILE) {
+			// File: description sidecars and MediaWiki: system pages (Common.js, the
+			// gadget definition and gadget code, ...) are saved as the current
+			// revision via a normal edit. For a File: page the upload already created
+			// it with a default description that an old revision would land behind;
+			// for MediaWiki: pages the edit hooks must fire so registries like the
+			// gadget list are invalidated before the pages render. importOldRevision
+			// would skip both.
+			if ($title->getNamespace() === NS_FILE || $title->getNamespace() === NS_MEDIAWIKI) {
 				$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
 				$updater = $page->newPageUpdater($user);
 				$updater->setContent(SlotRecord::MAIN, $content);
-				$updater->saveRevision(CommentStoreComment::newUnsavedComment('Set file description'));
+				$updater->saveRevision(CommentStoreComment::newUnsavedComment('Import'));
 				$this->output(" done\n");
 				continue;
 			}

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -24,10 +24,10 @@ require_once "$IP/maintenance/Maintenance.php";
  */
 class RewriteScripts extends Maintenance {
 	/** Module groups that are not shipped statically (mirrors Main/buildScripts). */
-	private const SKIP_GROUPS = ['site', 'noscript', 'private', 'user'];
+	private const SKIP_GROUPS = ['noscript', 'private', 'user'];
 
 	/** Modules excluded from the bundle, so they must not be triggered either. */
-	private const SKIP_MODULES = ['site', 'site.styles', 'user', 'user.styles', 'user.options'];
+	private const SKIP_MODULES = ['site.styles', 'user', 'user.styles', 'user.options'];
 
 	public function __construct() {
 		parent::__construct();
@@ -63,6 +63,13 @@ class RewriteScripts extends Maintenance {
 					}
 				}
 			}
+
+			// Make sure the site JS (MediaWiki:Common.js plus the skin's JS) and the
+			// gadgets enabled for every reader run: buildScripts bundles them, but
+			// the static render does not queue them, so trigger them here. Dedupe.
+			$trigger[] = 'site';
+			$trigger = array_merge($trigger, $this->defaultGadgetModules());
+			$trigger = array_values(array_unique($trigger));
 
 			// Stop the startup module from auto-loading anything over the network.
 			$html = preg_replace('/RLPAGEMODULES=\[[^\]]*\]/', 'RLPAGEMODULES=[]', $html);
@@ -115,6 +122,28 @@ class RewriteScripts extends Maintenance {
 
 			file_put_contents($file, $html, LOCK_EX);
 		}
+	}
+
+	/**
+	 * @return string[] Module names of the gadgets enabled for every reader (so
+	 *   they are triggered like the page's own modules), or an empty array when
+	 *   the Gadgets extension is not loaded.
+	 */
+	private function defaultGadgetModules() {
+		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
+		if (!class_exists($repoClass)) {
+			return [];
+		}
+		$modules = [];
+		$repo = $repoClass::singleton();
+		foreach ($repo->getGadgetIds() as $id) {
+			$gadget = $repo->getGadget($id);
+			// Styles-only gadgets belong in the CSS dump, not the JS bundle.
+			if ($gadget->isOnByDefault() && $gadget->hasModule() && $gadget->getType() !== 'styles') {
+				$modules[] = \MediaWiki\Extension\Gadgets\Gadget::getModuleName($id);
+			}
+		}
+		return $modules;
 	}
 
 	/**


### PR DESCRIPTION
## What

Implements the **JavaScript** planned feature: the wiki's own JavaScript runs in the static export, namely `MediaWiki:Common.js` (site JS) and **gadgets**.

- Site JS: add a `MediaWiki:Common.js.wikitext` file to your source. It (and the skin's `MediaWiki:Vector.js`, etc.) runs on every page.
- Gadgets: enable the bundled Gadgets extension in `.wikven.yaml`, then add `MediaWiki:Gadgets-definition.wikitext` and `MediaWiki:Gadget-<name>.js.wikitext`. Gadgets marked `default` load for every reader.

## How

The JS pipeline (`buildScripts` dumps a static bundle, `rewriteScripts` triggers it) previously **skipped** the `site` module and gadgets. Now:

- **`buildScripts` / `rewriteScripts`** stop skipping the `site` group/module, and **seed and trigger** `site` so Common.js runs.
- **Gadgets**: the single build process registers gadget modules on the ResourceLoader at boot, *before* the gadget definition pages are imported, so they are missing. The build now **re-registers** the gadget modules from the (by-then populated) gadget repo, and **seeds and triggers** the default-on gadgets. Guarded by `class_exists`, so it is a no-op without the Gadgets extension.
- **`importWikitext`** saves `MediaWiki:` namespace pages as the **current revision** (a normal edit) instead of `importOldRevision`, so edit hooks fire and the gadget registry is fresh when pages render.

## Verification

Built the image and verified in a real browser (served over HTTP, chrome-devtools):

- `MediaWiki:Common.js` executes (`site` module `ready`, marker injected). **No console errors.**
- A `default` gadget executes (`ext.gadget.<name>` `ready`, marker injected). **No console errors.**
- A source with **no** custom JS still builds and loads cleanly (empty `site` module, no errors).
- The real docs build is unaffected (no Common.js / Gadgets there) and the new docs page renders.

`mago` and `typos` pass.

## Notes / limitations

- Default gadgets are seeded on **all** pages; per-page load conditions (namespace/skin/action restrictions) are not evaluated. Fine for the usual unconditional default gadgets.
- **JS gadgets only.** A gadget's own CSS (in the same module) is included, but standalone **styles-only** gadgets and `MediaWiki:Common.css` are not covered here (CSS side, a possible follow-up).
- Touches `importWikitext` the same way **#38** does (which adds a `NS_FILE` current-edit branch). On merge the two current-edit branches should be combined into one condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
