### PR TITLE
feat: support third-party extensions and skins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM mediawiki:1.43
 
+# composer (and unzip, which composer uses to extract dist archives) so that
+# third-party extensions/skins declared in .wikven.yaml can be installed at build
+# time. git/tar/gzip are already in the base image for the git and tarball methods.
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends unzip \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY ./ /var/www/html/extensions/Wikven
 COPY WikvenSettings.php /var/www/html/
 

--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -1,6 +1,7 @@
 extensions:
   - SyntaxHighlight_GeSHi
   - ParserFunctions
+  - TemplateStyles
 skins:
   - Vector
 config:
@@ -9,3 +10,10 @@ config:
   WikvenHistoryUrl: https://github.com/chaotic-ground/wikven/commits/main/docs/$1.wikitext
   WikvenLogos:
     icon: logo.svg
+  WikvenRepositories:
+    # TemplateStyles is not bundled in the image; clone it from Git. Its only
+    # Composer dependency (wikimedia/css-sanitizer) already ships in MediaWiki
+    # core, so a plain clone is enough.
+    TemplateStyles:
+      repository: https://github.com/wikimedia/mediawiki-extensions-TemplateStyles.git
+      reference: REL1_43

--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -15,6 +15,20 @@ skins:
   - Timeless
 </syntaxhighlight>
 
+== Third-party skins ==
+
+A skin that is not bundled can be listed in <code>skins</code> too, with its source declared in [[wikven.yaml#WikvenRepositories|<code>WikvenRepositories</code>]]. It is fetched when the container runs and may be the default like any other.
+
+<syntaxhighlight lang="yaml">
+skins:
+  - Example
+config:
+  WikvenRepositories:
+    Example:
+      repository: https://github.com/example/Example.git
+      reference: REL1_43
+</syntaxhighlight>
+
 == Skin-specific configuration ==
 
 Use the <code>config</code> map.

--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -35,7 +35,7 @@ Use the <code>config</code> map.
 
 <syntaxhighlight lang="yaml">
 config:
-  VectorDefaultSkinVersion: "1"
+  VectorResponsive: false
 </syntaxhighlight>
 
 {{prevnext|JavaScript}}

--- a/docs/Template:hr.wikitext
+++ b/docs/Template:hr.wikitext
@@ -1,1 +1,1 @@
-<hr style="clear: both;">
+<templatestyles src="hr/styles.css" /><hr class="wikven-hr">

--- a/docs/Template:hr/styles.css.wikitext
+++ b/docs/Template:hr/styles.css.wikitext
@@ -1,0 +1,3 @@
+.wikven-hr {
+	clear: both;
+}

--- a/docs/Template:note.wikitext
+++ b/docs/Template:note.wikitext
@@ -1,10 +1,4 @@
-<div style="
-border: 0.2em solid lightgray;
-margin: 0.2em 1em;
-padding: 0.7em;
-display: flex;
-column-gap: 0.5em;
-"><!--
+<templatestyles src="note/styles.css" /><div class="wikven-note"><!--
   --><div>[[File:Xclamation SVG.svg|32px]]</div><!--
-  --><div style="vertical-align: middle;"><p>{{{1|Text here.}}}</p></div>
+  --><div class="wikven-note-text"><p>{{{1|Text here.}}}</p></div>
 </div>

--- a/docs/Template:note/styles.css.wikitext
+++ b/docs/Template:note/styles.css.wikitext
@@ -1,0 +1,11 @@
+.wikven-note {
+	border: 0.2em solid lightgray;
+	margin: 0.2em 1em;
+	padding: 0.7em;
+	display: flex;
+	column-gap: 0.5em;
+}
+
+.wikven-note-text {
+	vertical-align: middle;
+}

--- a/docs/Template:prevnext.wikitext
+++ b/docs/Template:prevnext.wikitext
@@ -4,9 +4,9 @@ Usage:
 * {{prevnext|next step}}
 * {{prevnext|previous step|next step}}
 
---><div style="clear: both; overflow: hidden;"><!--
+--><templatestyles src="prevnext/styles.css" /><div class="wikven-prevnext"><!--
   -->{{#if:{{{2|}}}|
-    <div style="float: left;">&larr;&nbsp;[[{{{1|}}}]]</div>
+    <div class="wikven-prevnext-prev">&larr;&nbsp;[[{{{1|}}}]]</div>
   }}<!--
-  --><div style="float: right;">[[{{{2|{{{1|}}}}}}]]&nbsp;&rarr;</div><!--
+  --><div class="wikven-prevnext-next">[[{{{2|{{{1|}}}}}}]]&nbsp;&rarr;</div><!--
 --></div>

--- a/docs/Template:prevnext/styles.css.wikitext
+++ b/docs/Template:prevnext/styles.css.wikitext
@@ -1,0 +1,12 @@
+.wikven-prevnext {
+	clear: both;
+	overflow: hidden;
+}
+
+.wikven-prevnext-prev {
+	float: left;
+}
+
+.wikven-prevnext-next {
+	float: right;
+}

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -10,6 +10,7 @@ With {{wikven}}, you can use the following features of MediaWiki.
 * [[Images|Images]] from Wikimedia Commons or local files
 * [[JavaScript]] (MediaWiki:Common.js and gadgets)
 * {{ml|Bundled extensions and skins}}
+* Third-party extensions and skins (see [[wikven.yaml|.wikven.yaml]])
 
 == Unsupported features ==
 
@@ -17,12 +18,6 @@ With {{wikven}}, you can use the following features of MediaWiki.
 * All special pages
 * All editors ({{ml|Extension:WikiEditor|WikiEditor}}, <!--
 -->{{ml|Extension:VisualEditor|VisualEditor}} and {{ml|Extension:CodeEditor|CodeEditor}})
-
-=== Planned features ===
-
-The following features are currently not supported, but are planned for the future.
-
-* Support for third-party skins/extensions
 
 {{prevnext|Getting Started}}
 {{DISPLAYTITLE:Wikven}}

--- a/docs/wikven.yaml.wikitext
+++ b/docs/wikven.yaml.wikitext
@@ -20,14 +20,14 @@ config:
 {{DISPLAYTITLE:.wikven.yaml}}
 
 == <code>extensions</code> ==
-A list of {{ml|Bundled extensions|bundled extension}} names to load.
+A list of extension names to load. {{ml|Bundled extensions|Bundled extensions}} work by name alone; a name that is not bundled is treated as third-party and fetched from a source you declare in [[#WikvenRepositories|<code>WikvenRepositories</code>]].
 
 == <code>skins</code> ==
-A list of bundled skin names to enable. The first one is used as the default skin. See [[Skins]].
+A list of skin names to enable. The first one is used as the default skin. As with extensions, a non-bundled name is fetched from [[#WikvenRepositories|<code>WikvenRepositories</code>]]. See [[Skins]].
 
 == <code>config</code> ==
 
-A map of configuration variables, each named without the <code>wg</code> prefix, just like in MediaWiki's YAML settings format. Any {{ml|Manual:Configuration settings|configuration setting}} can be defined here, including Wikven's own variables such as <code>WikvenFooterUrl</code>, <code>WikvenEditUrl</code>, <code>WikvenHistoryUrl</code>, and <code>WikvenLogos</code>.
+A map of configuration variables, each named without the <code>wg</code> prefix, just like in MediaWiki's YAML settings format. Any {{ml|Manual:Configuration settings|configuration setting}} can be defined here, including Wikven's own variables such as <code>WikvenFooterUrl</code>, <code>WikvenEditUrl</code>, <code>WikvenHistoryUrl</code>, <code>WikvenLogos</code>, and <code>WikvenRepositories</code>.
 
 === <code>WikvenLogos</code> ===
 
@@ -40,6 +40,36 @@ config:
 </syntaxhighlight>
 
 The values are file names instead of URLs in <code>$wgLogos</code> directly because the static export copies every referenced asset to a local file whose name includes a content hash that is only computed at build time. The logo's final address is therefore not known when you write the configuration, so <code>WikvenLogos</code> names the source file instead and the build inlines it as the logo.
+
+=== <code>WikvenRepositories</code> ===
+
+Sources for the third-party extensions and skins you list in <code>extensions</code> and <code>skins</code>. The lists stay plain names (the shape MediaWiki itself uses); this map says where to get the ones that are not bundled in the image. They are fetched when the container runs, before MediaWiki loads them. Whether an entry is an extension or a skin is taken from which list its name appears in, so you never write the name twice.
+
+Each entry chooses one of three methods by the key it carries:
+
+<syntaxhighlight lang="yaml">
+config:
+  WikvenRepositories:
+    # 1. A tarball, e.g. from Special:ExtensionDistributor, whose archive already
+    #    bundles the extension's dependencies.
+    Foo:
+      tarball: https://extdist.wmflabs.org/dist/extensions/Foo-REL1_43-abc1234.tar.gz
+    # 2. A Git repository. Add an optional reference (a tag or branch), and
+    #    composer: true to run Composer inside the cloned directory.
+    Bar:
+      repository: https://github.com/example/Bar.git
+      reference: REL1_43
+      composer: true
+    # 3. A Composer package, resolved through MediaWiki's composer.local.json.
+    SemanticMediaWiki:
+      package: mediawiki/semantic-media-wiki:~4.1
+</syntaxhighlight>
+
+A name in <code>WikvenRepositories</code> that already exists in the image (a bundled component) is left untouched. A name that is not also listed in <code>extensions</code> or <code>skins</code> is an error.
+
+{{note|The build downloads and runs the code you name here, with network access. Only declare sources you trust, and prefer pinning a <code>reference</code> or version.}}
+
+This very site fetches {{ml|Extension:TemplateStyles|TemplateStyles}} this way (see its <code>.wikven.yaml</code>) to style its templates; the notice box above is one example.
 
 == Defaults ==
 

--- a/extension.json
+++ b/extension.json
@@ -81,6 +81,10 @@
 		"WikvenLogos": {
 			"value": [],
 			"description": "Header logos, mirroring $wgLogos but keyed to image file names in the source directory (each inlined as a data URI)."
+		},
+		"WikvenRepositories": {
+			"value": [],
+			"description": "Sources for third-party extensions and skins listed in extensions/skins. A map of component name to a tarball/repository/package source, fetched by maintenance/fetchExtensions.php before MediaWiki loads them."
 		}
 	},
 	"MessagesDirs": {

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+use Maintenance;
+use MediaWiki\Settings\Source\Format\JsonFormat;
+use MediaWiki\Settings\Source\Format\YamlFormat;
+
+$IP = strval(getenv('MW_INSTALL_PATH')) !== ''
+	? getenv('MW_INSTALL_PATH')
+	: realpath(__DIR__ . '/../../../');
+
+require_once "$IP/maintenance/Maintenance.php";
+
+/**
+ * Fetch third-party extensions and skins before MediaWiki loads them.
+ *
+ * The `extensions:` and `skins:` lists in .wikven.yaml stay plain name lists, the
+ * same shape MediaWiki's own settings format accepts. A name that is not bundled
+ * in the image is fetched here, from a source declared in the `WikvenRepositories`
+ * config map. Each entry picks a method by which key it carries:
+ *
+ *   - `tarball:`    download and extract a tarball (e.g. from ExtensionDistributor,
+ *                   whose tarballs already bundle their dependencies).
+ *   - `repository:` git clone (plus optional `reference:` tag/branch, and
+ *                   `composer: true` to run composer inside the cloned directory).
+ *   - `package:`    a Composer "vendor/name:constraint" installed via the core
+ *                   composer.local.json (resolved by composer-merge-plugin).
+ *
+ * Whether a name is an extension or a skin is inferred from which list it appears
+ * in, so it is never written twice. This runs after install but before
+ * WikvenSettings is wired into LocalSettings, so its skins/extensions loops do not
+ * yet fire and no "not bundled" warning is logged while a component is still being
+ * fetched.
+ */
+class FetchExtensions extends Maintenance {
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription(
+			'Fetch third-party extensions and skins declared in .wikven.yaml.'
+		);
+	}
+
+	public function execute() {
+		$IP = $GLOBALS['IP'];
+
+		$config = $this->loadConfig($IP);
+
+		$repos = $config['config']['WikvenRepositories'] ?? [];
+		if (!is_array($repos) || $repos === []) {
+			return;
+		}
+
+		// Which list a name is in tells us where to put it.
+		$extensionNames = $this->nameSet($config['extensions'] ?? []);
+		$skinNames = $this->nameSet($config['skins'] ?? []);
+
+		// Composer's superuser warning would otherwise abort under set -e.
+		putenv('COMPOSER_ALLOW_SUPERUSER=1');
+
+		$packages = [];
+		foreach ($repos as $name => $spec) {
+			if (!is_string($name) || !is_array($spec)) {
+				$this->fatalError('Wikven: each WikvenRepositories entry must be a name mapped to a source.');
+			}
+			if ($name === '' || strpbrk($name, "/\\") !== false || str_starts_with($name, '.')) {
+				$this->fatalError("Wikven: invalid component name '$name' in WikvenRepositories.");
+			}
+
+			[$baseDir, $kind] = $this->target($name, $extensionNames, $skinNames);
+
+			if (isset($spec['package'])) {
+				// Composer chooses the install directory from the package, so there
+				// is nothing to place by hand; just collect the requirement.
+				if (!is_string($spec['package']) || $spec['package'] === '') {
+					$this->fatalError("Wikven: $kind '$name' has an empty 'package'.");
+				}
+				[$pkgName, $constraint] = $this->splitPackage($spec['package']);
+				$packages[$pkgName] = $constraint;
+				$this->output("Wikven: will install $kind '$name' as composer package $pkgName ($constraint)\n");
+				continue;
+			}
+
+			$dest = "$baseDir/$name";
+			if (is_dir($dest)) {
+				// Already bundled in the image, or cloned by an earlier run. The
+				// bundled copy wins; we never overwrite it.
+				$this->output("Wikven: $kind '$name' already present, skipping.\n");
+				continue;
+			}
+
+			if (isset($spec['tarball'])) {
+				$this->fetchTarball((string)$spec['tarball'], $dest, $name, $kind);
+			} elseif (isset($spec['repository'])) {
+				$this->fetchGit($spec, $dest, $name, $kind);
+			} else {
+				$this->fatalError(
+					"Wikven: $kind '$name' must declare one of: tarball, repository, package."
+				);
+			}
+		}
+
+		if ($packages !== []) {
+			$this->installPackages($IP, $packages);
+		}
+	}
+
+	/**
+	 * Read and merge default.yaml + the site's .wikven.yaml/.json, exactly as
+	 * WikvenSettings.php does, so the fetched set matches what will be loaded.
+	 *
+	 * @param string $IP
+	 * @return array
+	 */
+	private function loadConfig($IP) {
+		$yaml = new YamlFormat();
+		$config = $yaml->decode(file_get_contents("$IP/extensions/Wikven/default.yaml"));
+
+		$siteFile = null;
+		if (file_exists('/workspace/src/.wikven.yaml')) {
+			$siteFile = '/workspace/src/.wikven.yaml';
+		} elseif (file_exists('/workspace/src/.wikven.json')) {
+			$siteFile = '/workspace/src/.wikven.json';
+		}
+		if ($siteFile !== null) {
+			$format = str_ends_with($siteFile, '.json') ? new JsonFormat() : $yaml;
+			$site = $format->decode(file_get_contents($siteFile));
+			$config['config'] = array_merge($config['config'] ?? [], $site['config'] ?? []);
+			$config['extensions'] = array_merge($config['extensions'] ?? [], $site['extensions'] ?? []);
+			$config['skins'] = array_merge($config['skins'] ?? [], $site['skins'] ?? []);
+		}
+
+		return $config;
+	}
+
+	/**
+	 * @param array $list
+	 * @return array<string,true> Set of the string names in $list.
+	 */
+	private function nameSet(array $list) {
+		$set = [];
+		foreach ($list as $entry) {
+			if (is_string($entry)) {
+				$set[$entry] = true;
+			}
+		}
+		return $set;
+	}
+
+	/**
+	 * @param string $name
+	 * @param array<string,true> $extensionNames
+	 * @param array<string,true> $skinNames
+	 * @return array{0:string,1:string} [base directory, kind]
+	 */
+	private function target($name, array $extensionNames, array $skinNames) {
+		$IP = $GLOBALS['IP'];
+		if (isset($extensionNames[$name])) {
+			return ["$IP/extensions", 'extension'];
+		}
+		if (isset($skinNames[$name])) {
+			return ["$IP/skins", 'skin'];
+		}
+		$this->fatalError(
+			"Wikven: WikvenRepositories entry '$name' is not listed in extensions: or skins:."
+		);
+	}
+
+	/**
+	 * @param string $package "vendor/name" or "vendor/name:constraint"
+	 * @return array{0:string,1:string} [package name, version constraint]
+	 */
+	private function splitPackage($package) {
+		$pos = strpos($package, ':');
+		if ($pos === false) {
+			return [$package, '*'];
+		}
+		return [substr($package, 0, $pos), substr($package, $pos + 1)];
+	}
+
+	private function fetchTarball($url, $dest, $name, $kind) {
+		$this->output("Wikven: downloading $kind '$name' from $url\n");
+		$tmp = tempnam(sys_get_temp_dir(), 'wikven');
+		$this->run(['curl', '-sSL', '-f', '-o', $tmp, '--', $url], "download $kind '$name'");
+		if (!mkdir($dest, 0777, true) && !is_dir($dest)) {
+			$this->fatalError("Wikven: could not create '$dest'.");
+		}
+		$this->run(['tar', '-xzf', $tmp, '-C', $dest, '--strip-components=1'], "extract $kind '$name'");
+		unlink($tmp);
+	}
+
+	private function fetchGit(array $spec, $dest, $name, $kind) {
+		$repo = (string)$spec['repository'];
+		$cmd = ['git', 'clone', '--depth', '1'];
+		if (!empty($spec['reference'])) {
+			// --branch takes a tag or a branch (not an arbitrary commit SHA).
+			$cmd[] = '--branch';
+			$cmd[] = (string)$spec['reference'];
+		}
+		array_push($cmd, '--', $repo, $dest);
+		$this->output(
+			"Wikven: cloning $kind '$name' from $repo"
+			. ( !empty($spec['reference']) ? " @ {$spec['reference']}" : '' )
+			. "\n"
+		);
+		$this->run($cmd, "clone $kind '$name'");
+
+		if (!empty($spec['composer'])) {
+			$this->run(
+				['composer', 'update', '--no-dev', '--no-interaction', '--working-dir=' . $dest],
+				"composer install for $kind '$name'"
+			);
+		}
+	}
+
+	/**
+	 * @param string $IP
+	 * @param array<string,string> $packages package name => constraint
+	 */
+	private function installPackages($IP, array $packages) {
+		// Core's composer.json merges composer.local.json via composer-merge-plugin,
+		// so registering the requirement there and running composer update at the
+		// root pulls each package (and its dependencies) into place.
+		$localFile = "$IP/composer.local.json";
+		$local = is_file($localFile)
+			? ( json_decode(file_get_contents($localFile), true) ?: [] )
+			: [];
+		$local['require'] = array_merge($local['require'] ?? [], $packages);
+		file_put_contents(
+			$localFile,
+			json_encode($local, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n"
+		);
+
+		$this->run(
+			['composer', 'update', '--no-dev', '--no-interaction', '--working-dir=' . $IP],
+			'composer update'
+		);
+	}
+
+	/**
+	 * Run an external command, aborting the build if it fails. A declared
+	 * third-party dependency that cannot be fetched must fail loudly rather than
+	 * silently produce a wiki missing the feature.
+	 *
+	 * @param string[] $cmd
+	 * @param string $what
+	 */
+	private function run(array $cmd, $what) {
+		$shell = implode(' ', array_map('escapeshellarg', $cmd));
+		$ret = 0;
+		passthru($shell, $ret);
+		if ($ret !== 0) {
+			$this->fatalError("Wikven: failed to $what (exit $ret).");
+		}
+	}
+}
+
+$maintClass = FetchExtensions::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -34,8 +34,8 @@ class ImportWikitext extends Maintenance {
 		StubGlobalUser::setUser($user);
 
 		$ok = true;
-		foreach (glob("$sourceDirectory/*.wikitext") as $filename) {
-			$title = Title::newFromText($this->filenameToTitle($filename));
+		foreach ($this->wikitextFiles($sourceDirectory) as $filename) {
+			$title = Title::newFromText($this->filenameToTitle($filename, $sourceDirectory));
 			if (!$title) {
 				$this->output('Invalid title: ' . basename($filename) . "\n");
 				continue;
@@ -85,13 +85,40 @@ class ImportWikitext extends Maintenance {
 	}
 
 	/**
+	 * Find every *.wikitext file under the source directory, recursing into
+	 * subdirectories so subpages can be supplied as nested files (e.g. a
+	 * template's "Template:Foo/styles.css.wikitext" in a "Template:Foo/" folder).
+	 *
+	 * @param string $sourceDirectory
+	 * @return string[] Absolute paths, sorted for a stable import order.
+	 */
+	private function wikitextFiles($sourceDirectory) {
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator($sourceDirectory, \FilesystemIterator::SKIP_DOTS)
+		);
+		$files = [];
+		foreach ($iterator as $file) {
+			if ($file->isFile() && str_ends_with($file->getFilename(), '.wikitext')) {
+				$files[] = $file->getPathname();
+			}
+		}
+		sort($files);
+		return $files;
+	}
+
+	/**
+	 * Map a wikitext file to its page title: the path relative to the source
+	 * directory, minus the .wikitext suffix. A nested file thus becomes a
+	 * subpage, so "Template:Foo/styles.css.wikitext" imports as the subpage
+	 * "Template:Foo/styles.css".
+	 *
 	 * @param string $name
+	 * @param string $sourceDirectory
 	 * @return string
 	 */
-	private function filenameToTitle($name) {
-		$name = basename($name);
-		$name = preg_replace('/\.wikitext$/', '', $name);
-		return $name;
+	private function filenameToTitle($name, $sourceDirectory) {
+		$relative = substr($name, strlen($sourceDirectory) + 1);
+		return preg_replace('/\.wikitext$/', '', $relative);
 	}
 }
 

--- a/run
+++ b/run
@@ -12,6 +12,11 @@ php maintenance/run.php install \
   MediaWiki \
   Admin
 
+# Fetch third-party extensions/skins before WikvenSettings is wired in, so they
+# are on disk when the build boot loads them (and no "not bundled" warnings fire
+# while they are still being fetched).
+php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/fetchExtensions.php
+
 echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
 
 php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/build.php


### PR DESCRIPTION
## What

Adds the last "Planned feature": **third-party extensions and skins**, declared in `.wikven.yaml` and fetched when the container runs.

> [!NOTE]
> Stacked on #41 (default.yaml) — the base is `default-yaml` and will retarget to `main` once #41 merges. The fetch step reuses the same default.yaml + .wikven.yaml merge.

## Design

`extensions:`/`skins:` stay plain MediaWiki-compatible **name lists**. A Wikven-prefixed `WikvenRepositories` config map (like `WikvenLogos`) says where to get the non-bundled ones. Each entry chooses a method by the key it carries:

```yaml
config:
  WikvenRepositories:
    Foo:                       # ExtensionDistributor tarball (deps bundled)
      tarball: https://extdist.wmflabs.org/dist/extensions/Foo-REL1_43-abc.tar.gz
    Bar:                       # git clone (+ optional reference, composer: true)
      repository: https://github.com/example/Bar.git
      reference: REL1_43
      composer: true
    SemanticMediaWiki:         # Composer package via composer.local.json
      package: mediawiki/semantic-media-wiki:~4.1
```

Extension-vs-skin is inferred from which list the name appears in, so it is never written twice.

## How

- **`maintenance/fetchExtensions.php`** (new): runs in `run` after install but before `WikvenSettings.php` is appended to `LocalSettings.php`, so the files are present when the build boot loads them and no "not bundled" warning fires mid-fetch. Fatals on any fetch failure; guards path traversal and shell option-injection.
- **`Dockerfile`**: add `composer` (from `composer:2`) + `unzip` for the Composer methods. git/tar/gzip already ship in the base image.
- **`WikvenSettings.php`**: unchanged — the load loops still take plain string names, now backed by the fetched files.
- **`importWikitext.php`**: recurse into subdirectories and title pages by their path relative to the source dir, so subpages work as nested files (needed for `Template:Foo/styles.css`).
- **Docs**: third-party moves from Planned → Supported (`index`); new `WikvenRepositories` reference section with a security note (`wikven.yaml`); third-party skins subsection (`Skins`).

## Dogfood

The docs site fetches **TemplateStyles** from Git (`REL1_43`; its one Composer dep `wikimedia/css-sanitizer` already ships in core) and the templates' inline `style=` attributes become `<templatestyles>` + `.css` subpages. The notice box and prev/next nav on the live site are rendered by it.

## Verification

Real `docker build` + run against `docs/`: TemplateStyles clones and loads (no "skipping" warning), the `.css` subpages import with the `sanitized-css` content model, 6 pages emit scoped `<style data-mw-deduplicate="TemplateStyles:…">` blocks, no TemplateStyles errors site-wide, and no browser console errors. `mago fmt` clean, `extension.json` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
