### PR TITLE
refactor: derive paths from WIKVEN_WORKDIR and detect the image backend

### DIFF
--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -5,10 +5,39 @@ wfLoadExtension('Wikven');
 // Build mechanics. The user-overridable MediaWiki defaults live in default.yaml;
 // only the static-export internals that are not plain config stay here.
 
+// All filesystem locations derive from one working directory so the same build
+// works in the Docker image (where /workspace is mounted) and in a standalone
+// binary (where it points at a writable host directory). Layout:
+//   $WIKVEN_WORKDIR/src    input (read-only)
+//   $WIKVEN_WORKDIR/dist   output (the rendered file cache)
+//   $WIKVEN_WORKDIR/.cache ephemeral state (uploads, l10n + object cache, tmp)
+$wikvenWorkEnv = getenv('WIKVEN_WORKDIR');
+$wikvenWork = $wikvenWorkEnv !== false && $wikvenWorkEnv !== '' ? $wikvenWorkEnv : '/workspace';
+$wikvenSrc = "$wikvenWork/src";
+$wikvenDist = "$wikvenWork/dist";
+$wikvenCache = "$wikvenWork/.cache";
+
 // The static export is MediaWiki's own file cache, written to the output dir.
 $wgUseFileCache = true;
 $wgFileCacheDepth = 0;
-$wgFileCacheDirectory = '/workspace/dist';
+$wgFileCacheDirectory = $wikvenDist;
+$wgWikvenSourceDirectory = $wikvenSrc;
+$wgWikvenHtmlDirectory = $wikvenDist;
+
+// Standalone-binary mode (WIKVEN_WORKDIR set): keep every ephemeral write out of
+// the install dir, which in the embedded binary is an extracted, throwaway tree.
+// In the Docker image WIKVEN_WORKDIR is unset, the install dir is writable, and
+// MediaWiki's defaults are left untouched (no behavior change).
+if ($wikvenWorkEnv !== false && $wikvenWorkEnv !== '') {
+	$wgUploadDirectory = "$wikvenCache/uploads";
+	$wgCacheDirectory = "$wikvenCache/mw";
+	$wgTmpDirectory = "$wikvenCache/tmp";
+	foreach ([$wgUploadDirectory, $wgCacheDirectory, $wgTmpDirectory] as $wikvenDir) {
+		if (!is_dir($wikvenDir)) {
+			@mkdir($wikvenDir, 0777, true);
+		}
+	}
+}
 
 // Ship a small built-in favicon so browsers do not 404 on /favicon.ico.
 // Overridable from .wikven.yaml via "config": { "Favicon": "..." }.
@@ -22,6 +51,48 @@ $wgFavicon = 'data:image/svg+xml,'
 
 unset($wgFooterIcons['poweredby']);
 
+// Image backend, detected at run time so the build uses whatever the host has.
+// Raster thumbnails (png/jpg/gif/webp) go through ImageMagick when its `convert`
+// (or `magick`) is on PATH, otherwise the GD extension. SVG goes through
+// rsvg-convert when present, otherwise it is served inline as sanitized native
+// SVG. SVG is deliberately never routed through ImageMagick, whose built-in
+// 'ImageMagick' converter calls the `convert` binary that does not exist on
+// ImageMagick-7-only hosts. This runs before the config load below, so an
+// explicit value in .wikven.yaml still wins; default.yaml does not set the
+// backend. In the Docker image both tools are present, so this reproduces the
+// previous ImageMagick + rsvg configuration exactly.
+$wikvenFindExe = static function (array $names) {
+	$path = getenv('PATH') ?: '/usr/local/bin:/usr/bin:/bin';
+	foreach ($names as $name) {
+		foreach (explode(':', $path) as $dir) {
+			if ($dir !== '' && is_executable(rtrim($dir, '/') . '/' . $name)) {
+				return rtrim($dir, '/') . '/' . $name;
+			}
+		}
+	}
+	return null;
+};
+$wikvenConvert = $wikvenFindExe(['convert', 'magick']);
+$wikvenRsvg = $wikvenFindExe(['rsvg-convert']);
+$wgUseImageMagick = $wikvenConvert !== null;
+if ($wikvenConvert !== null) {
+	$wgImageMagickConvertCommand = $wikvenConvert;
+}
+if ($wikvenRsvg !== null) {
+	$wgSVGConverter = 'rsvg';
+	$wgSVGConverterPath = dirname($wikvenRsvg);
+} else {
+	$wgSVGNativeRendering = true;
+}
+if ($wikvenConvert === null || $wikvenRsvg === null) {
+	error_log(
+		'Wikven: '
+		. ( $wikvenConvert === null ? 'ImageMagick not found, using GD for raster thumbnails. ' : '' )
+		. ( $wikvenRsvg === null ? 'rsvg-convert not found, serving SVG inline (native). ' : '' )
+		. 'Install ImageMagick and librsvg for higher-quality thumbnails.'
+	);
+}
+
 // Configuration: wikven's defaults (default.yaml) merged with the site's own
 // .wikven.yaml (or .wikven.json), the site overriding the defaults. Both use
 // MediaWiki's YAML settings format: a "config" map (variables without the "wg"
@@ -32,13 +103,13 @@ $wikvenYaml = new MediaWiki\Settings\Source\Format\YamlFormat();
 $config = $wikvenYaml->decode(file_get_contents("$IP/extensions/Wikven/default.yaml"));
 
 $wikvenSiteFile = null;
-if (file_exists('/workspace/src/.wikven.yaml')) {
-	$wikvenSiteFile = '/workspace/src/.wikven.yaml';
-	if (file_exists('/workspace/src/.wikven.json')) {
+if (file_exists("$wikvenSrc/.wikven.yaml")) {
+	$wikvenSiteFile = "$wikvenSrc/.wikven.yaml";
+	if (file_exists("$wikvenSrc/.wikven.json")) {
 		error_log('Wikven: both .wikven.yaml and .wikven.json exist; using .wikven.yaml and ignoring .wikven.json');
 	}
-} elseif (file_exists('/workspace/src/.wikven.json')) {
-	$wikvenSiteFile = '/workspace/src/.wikven.json';
+} elseif (file_exists("$wikvenSrc/.wikven.json")) {
+	$wikvenSiteFile = "$wikvenSrc/.wikven.json";
 }
 
 if ($wikvenSiteFile !== null) {
@@ -106,8 +177,8 @@ foreach ($config['config'] ?? [] as $key => $val) {
 // either a file name, or (like $wgLogos['wordmark'] and ['tagline']) a map with a
 // "src" file name plus extra keys such as width and height.
 if (!empty($wgWikvenLogos) && is_array($wgWikvenLogos)) {
-	$wikvenLogoData = static function ($name) {
-		$file = '/workspace/src/' . $name;
+	$wikvenLogoData = static function ($name) use ($wikvenSrc) {
+		$file = "$wikvenSrc/" . $name;
 		if (!is_file($file)) {
 			error_log("Wikven: logo file '$name' not found in the source directory");
 			return null;

--- a/default.yaml
+++ b/default.yaml
@@ -23,14 +23,12 @@ config:
   UseInstantCommons: true
 
   # Local images: source-directory image files are uploaded into the File:
-  # namespace at build time. ImageMagick scales raster thumbnails; rsvg-convert
-  # rasterizes SVG thumbnails.
+  # namespace at build time. The thumbnailing backend (ImageMagick or GD, and
+  # rsvg or native SVG) is not set here; WikvenSettings.php detects it at run time
+  # from the tools available on the host, so the same build works in the Docker
+  # image and in a standalone binary that has only GD.
   EnableUploads: true
-  UseImageMagick: true
-  ImageMagickConvertCommand: /usr/bin/convert
   FileExtensions: [png, gif, jpg, jpeg, webp, svg]
-  SVGConverter: rsvg
-  SVGConverterPath: /usr/bin
 
   # Which namespaces count as content. MediaWiki's default is the main namespace
   # alone ([0]); Wikven adds File: (namespace 6) so the file cache exports file

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -116,11 +116,13 @@ class FetchExtensions extends Maintenance {
 		$yaml = new YamlFormat();
 		$config = $yaml->decode(file_get_contents("$IP/extensions/Wikven/default.yaml"));
 
+		$work = getenv('WIKVEN_WORKDIR');
+		$src = $work !== false && $work !== '' ? "$work/src" : '/workspace/src';
 		$siteFile = null;
-		if (file_exists('/workspace/src/.wikven.yaml')) {
-			$siteFile = '/workspace/src/.wikven.yaml';
-		} elseif (file_exists('/workspace/src/.wikven.json')) {
-			$siteFile = '/workspace/src/.wikven.json';
+		if (file_exists("$src/.wikven.yaml")) {
+			$siteFile = "$src/.wikven.yaml";
+		} elseif (file_exists("$src/.wikven.json")) {
+			$siteFile = "$src/.wikven.json";
 		}
 		if ($siteFile !== null) {
 			$format = str_ends_with($siteFile, '.json') ? new JsonFormat() : $yaml;

--- a/run
+++ b/run
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail; IFS=$'\n\t'
 
+# Source input and rendered output live under one working dir, matching
+# WikvenSettings.php. Defaults to /workspace, the path the image mounts.
+WIKVEN_WORKDIR="${WIKVEN_WORKDIR:-/workspace}"
+
 cd /var/www/html
 
 php maintenance/run.php install \
@@ -20,4 +24,4 @@ php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/fetchExtensi
 echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
 
 php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/build.php
-rm -rf /workspace/dist/history/
+rm -rf "$WIKVEN_WORKDIR/dist/history/"


### PR DESCRIPTION
## What

Two small, coupled changes that make a single wikven build work both in the Docker image and (later) in a standalone binary, with **no change to the Docker build**. Groundwork for #42 (FrankenPHP binary).

## 1. Paths derive from `WIKVEN_WORKDIR`

`WikvenSettings.php` and `maintenance/fetchExtensions.php` both hardcoded `/workspace/src`. They now derive from `WIKVEN_WORKDIR` (default `/workspace`):

```
$WIKVEN_WORKDIR/src     input (read-only)
$WIKVEN_WORKDIR/dist    output (the rendered file cache)
$WIKVEN_WORKDIR/.cache  ephemeral state (uploads, l10n/object cache, tmp)
```

The ephemeral redirect into `.cache/` happens **only when `WIKVEN_WORKDIR` is set**, so an embedded binary never writes into its extracted, throwaway app tree. With the var unset, MediaWiki's defaults are untouched, the Docker image and CI are byte-for-byte unaffected.

## 2. Image backend detected at run time

Instead of pinning `UseImageMagick`/`ImageMagickConvertCommand`/`SVGConverter`/`SVGConverterPath` in `default.yaml`, `WikvenSettings.php` detects the host's tools:

- raster (png/jpg/gif/webp): ImageMagick (`convert`/`magick`) if on PATH, else the GD extension;
- SVG: `rsvg-convert` if present, else `$wgSVGNativeRendering` (sanitized inline SVG), with a warning.

SVG is deliberately never routed through ImageMagick's `convert`-based template (missing on ImageMagick-7-only hosts). Detection runs before the config load, so an explicit value in `.wikven.yaml` still wins. In the Docker image both tools are present, so this reproduces the previous ImageMagick + rsvg config exactly.

## Verification

Built the docs with this branch and with `main`, and diffed the output: identical modulo per-build nondeterminism (`wgRequestId`, cache timestamps, CPU/timing, and one PNG ImageMagick stamps a timestamp into, which already differs between two runs of `main`). Same thumbnails, same TemplateStyles, same config. `mago fmt` clean.

The standalone-binary path this unblocks was validated separately (a FrankenPHP binary embedding MediaWiki built the same docs site end-to-end); details in #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
