### PR TITLE
feat: distribute a standalone binary

### DIFF
--- a/.github/workflows/release-binary.yaml
+++ b/.github/workflows/release-binary.yaml
@@ -1,0 +1,44 @@
+name: Release binary
+
+# When release-please publishes a GitHub Release, build the standalone binary
+# (one per architecture) and attach it to that release.
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  binary:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write # gh release upload
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # The standalone binary embeds the same MediaWiki + Wikven tree the image
+      # ships, so build that image first, then embed it into a FrankenPHP binary.
+      - name: Build the embedding image
+        run: docker build -t wikven .
+
+      - name: Build the standalone binary
+        run: docker build -f Dockerfile.binary --target export -o type=local,dest=out .
+
+      - name: Name it per architecture
+        run: mv out/wikven "wikven-linux-${{ matrix.arch }}"
+
+      - name: Attach to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG" "wikven-linux-${{ matrix.arch }}" --clobber

--- a/Dockerfile.binary
+++ b/Dockerfile.binary
@@ -1,0 +1,37 @@
+# Build a standalone FrankenPHP binary that embeds MediaWiki + Wikven, so the
+# static-site build runs without Docker. Built in CI per target architecture and
+# attached to the GitHub release; see .github/workflows/release-binary.yaml.
+#
+# Usage (the wikven image must be built first, e.g. `docker build -t wikven .`):
+#   docker build -f Dockerfile.binary --target export -o type=local,dest=out .
+#   # -> out/wikven, a single static executable. Run it with:
+#   #    WIKVEN_WORKDIR=. ./wikven php-cli build.php
+
+# Stage 1: the app tree to embed = the wikven image + the binary entry point,
+# minus what the build never needs (keeping all locales, so the binary is not
+# English-only).
+FROM wikven AS app
+COPY bin/build.php /var/www/html/build.php
+RUN find /var/www/html -type d -name tests -prune -exec rm -rf {} + \
+ && rm -rf \
+      /var/www/html/HISTORY \
+      /var/www/html/UPGRADE \
+      /var/www/html/RELEASE-NOTES-* \
+      /var/www/html/cache/* \
+      /var/www/html/images/*
+
+# Stage 2: compile a static PHP + FrankenPHP and embed the app. curl is omitted:
+# its HTTP/3 (ngtcp2/nghttp3) static libs fail to link, and it is unneeded
+# (MediaWiki/Guzzle uses PHP stream wrappers over openssl).
+FROM dunglas/frankenphp:static-builder-musl AS builder
+WORKDIR /go/src/app
+COPY --from=app /var/www/html ./dist/app
+ENV PHP_VERSION=8.3
+ENV PHP_EXTENSIONS="gd,intl,pdo_sqlite,sqlite3,mbstring,dom,xml,simplexml,xmlreader,xmlwriter,fileinfo,iconv,ctype,filter,tokenizer,phar,session,calendar,opcache,openssl,sodium,zlib,bcmath,exif"
+ENV PHP_EXTENSION_LIBS="libpng,libjpeg,freetype,libwebp"
+RUN EMBED=dist/app ./build-static.sh
+
+# Stage 3: expose just the binary (named per arch by build-static.sh) for
+# `docker build --target export -o`.
+FROM scratch AS export
+COPY --from=builder /go/src/app/dist/frankenphp-linux-* /wikven

--- a/bin/build.php
+++ b/bin/build.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Standalone-binary entry point: build the whole static site in one invocation.
+ *
+ *   WIKVEN_WORKDIR=/path/to/work  ./wikven php-cli build.php
+ *
+ * Reads $WIKVEN_WORKDIR/src (input), writes $WIKVEN_WORKDIR/dist (output), and
+ * keeps ephemeral state in $WIKVEN_WORKDIR/.cache. WIKVEN_WORKDIR defaults to the
+ * current directory.
+ *
+ * The binary embeds MediaWiki; this script drives the same steps the Docker
+ * `run` script does (install, then load WikvenSettings, then fetch third-party
+ * components, then build) by re-invoking the binary once per step. It is shipped
+ * to the embed root by Dockerfile.binary, so php-cli finds it as "build.php".
+ */
+
+// __DIR__ is the extracted, writable embed root (MediaWiki's $IP).
+$ip = __DIR__;
+
+// Re-invoking the build steps means running the wikven binary again. FrankenPHP
+// leaves PHP_BINARY empty in CLI mode, so resolve the running executable via
+// /proc/self/exe (read inside PHP to get the real path; the literal string
+// "/proc/self/exe" must not be passed to a subshell, where it would resolve to
+// the shell instead).
+$self = PHP_BINARY;
+if ($self === '' || !is_executable($self)) {
+	$self = @readlink('/proc/self/exe') ?: '';
+}
+if ($self === '' || !is_executable($self)) {
+	fwrite(STDERR, "wikven: cannot locate the wikven executable to run build steps\n");
+	exit(1);
+}
+
+$work = getenv('WIKVEN_WORKDIR');
+if ($work === false || $work === '') {
+	$work = getcwd();
+}
+$work = rtrim($work, '/');
+putenv("WIKVEN_WORKDIR=$work");
+$_ENV['WIKVEN_WORKDIR'] = $work;
+
+// Static binaries bundle no CA certificates; point openssl at the host bundle so
+// InstantCommons (HTTPS) and git-over-HTTPS work, unless the user set it already.
+if (getenv('SSL_CERT_FILE') === false) {
+	foreach ([
+		'/etc/ssl/certs/ca-certificates.crt',
+		'/etc/pki/tls/certs/ca-bundle.crt',
+		'/etc/ssl/cert.pem'
+	] as $ca) {
+		if (is_file($ca)) {
+			putenv("SSL_CERT_FILE=$ca");
+			$_ENV['SSL_CERT_FILE'] = $ca;
+			break;
+		}
+	}
+}
+
+if (!is_dir("$work/src")) {
+	fwrite(STDERR, "wikven: no source directory at $work/src\n");
+	exit(1);
+}
+@mkdir("$work/dist", 0777, true);
+@mkdir("$work/.cache", 0777, true);
+
+// Start each run from a clean slate: the embed root may persist between runs
+// (same checksum extracts to the same /tmp dir), so drop any prior install.
+@unlink("$ip/LocalSettings.php");
+foreach (glob("$work/.cache/*.sqlite") ?: [] as $stale) {
+	@unlink($stale);
+}
+
+// Run an embedded maintenance script by re-invoking the binary. The script path
+// for php-cli is resolved relative to the embed root, so maintenance/run.php is
+// passed relatively while the scripts it runs are passed as absolute paths.
+$run = static function (array $args) use ($self, $ip) {
+	$cmd = array_merge([$self, 'php-cli', 'maintenance/run.php'], $args);
+	passthru(implode(' ', array_map('escapeshellarg', $cmd)), $code);
+	if ($code !== 0) {
+		fwrite(STDERR, "wikven: build step failed (exit $code)\n");
+		exit($code);
+	}
+};
+
+// 1. Install MediaWiki: creates the SQLite schema and LocalSettings.php in $ip.
+$run([
+	'install',
+	'--dbtype',
+	'sqlite',
+	'--dbpath',
+	"$work/.cache",
+	'--scriptpath',
+	'',
+	'--pass',
+	'adminpassword',
+	'MediaWiki',
+	'Admin'
+]);
+
+// 2. Wire in WikvenSettings (the extracted root is writable).
+file_put_contents("$ip/LocalSettings.php", "\nrequire_once '$ip/WikvenSettings.php';\n", FILE_APPEND);
+
+// 3. Fetch third-party extensions/skins, then 4. build the static site.
+$run(["$ip/extensions/Wikven/maintenance/fetchExtensions.php"]);
+$run(["$ip/extensions/Wikven/maintenance/build.php"]);
+
+// Drop the per-page history the file cache emits, as the Docker run does.
+$history = "$work/dist/history";
+if (is_dir($history)) {
+	passthru('rm -rf ' . escapeshellarg($history));
+}
+
+fwrite(STDERR, "wikven: done -> $work/dist\n");

--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -1,0 +1,42 @@
+__TOC__
+
+Besides the [[Getting Started|Docker image]], {{wikven}} ships as a single self-contained executable that embeds MediaWiki, so you can build a site without Docker. It is available for Linux on x86_64 and arm64.
+
+== Download ==
+
+Download the binary for your architecture from the [https://github.com/chaotic-ground/wikven/releases latest release] and make it executable:
+
+<syntaxhighlight lang="shell">
+curl -L -o wikven https://github.com/chaotic-ground/wikven/releases/latest/download/wikven-linux-x86_64
+chmod +x wikven
+</syntaxhighlight>
+
+On arm64, use <code>wikven-linux-aarch64</code>.
+
+== Building a site ==
+
+Put your wikitext and a [[wikven.yaml|.wikven.yaml]] in a <code>src/</code> directory, then build:
+
+<syntaxhighlight lang="shell">
+mkdir -p src
+echo 'Hello, World!' > src/index.wikitext
+./wikven php-cli build.php
+</syntaxhighlight>
+
+The rendered site is written to <code>dist/</code>. The working directory defaults to the current directory; set <code>WIKVEN_WORKDIR</code> to build a project elsewhere:
+
+<syntaxhighlight lang="shell">
+WIKVEN_WORKDIR=/path/to/project ./wikven php-cli build.php
+</syntaxhighlight>
+
+The output is the same as the Docker image's: the binary embeds MediaWiki, the bundled extensions and skins, and every interface language.
+
+== Optional host tools ==
+
+The binary renders on its own, but uses these host programs when they are present:
+
+* '''ImageMagick''' and '''librsvg''' produce higher-quality thumbnails. Without them the binary uses the built-in GD library for raster images and serves SVG inline. See [[Images]].
+* '''git''' is needed only to fetch [[wikven.yaml#WikvenRepositories|third-party extensions and skins]].
+
+{{prevnext|Getting Started}}
+{{DISPLAYTITLE:Standalone binary}}

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -2,7 +2,8 @@ On this page, we build a basic [[mw:en:"Hello, World!" program|Hello World]] pag
 {{note|This page assumes a unix-like OS.}}
 
 {{wikven}} consists of two parts: a script and a MediaWiki extension. To simplify the whole build
-process, a docker image is provided, and this guide shows how to use it.
+process, a docker image is provided, and this guide shows how to use it. If you would rather not
+use Docker, there is also a [[Binary|standalone binary]].
 
 ; Requirement
 :* [https://www.docker.com/ Docker]

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -2,6 +2,7 @@
 ** mainpage|mainpage-description
 * Docs
 ** Getting Started|Getting Started
+** Binary|Standalone binary
 ** Editing sidebar|Editing sidebar
 ** Images|Images
 ** Skins|Skins


### PR DESCRIPTION
## What

Distribute wikven as a **single self-contained FrankenPHP binary** that embeds MediaWiki, so a site can be built with no Docker (closes the productionization half of #42).

```shell
curl -L -o wikven https://github.com/chaotic-ground/wikven/releases/latest/download/wikven-linux-x86_64
chmod +x wikven
mkdir -p src && echo 'Hello, World!' > src/index.wikitext
./wikven php-cli build.php          # -> dist/
```

## How

- **`Dockerfile.binary`** embeds the MediaWiki + Wikven tree into a static FrankenPHP binary via the `static-php-cli` builder. Trims `tests/` and release notes (keeps all locales, so the binary is not English-only). `curl` is omitted — its HTTP/3 (ngtcp2/nghttp3) static libs fail to link and MediaWiki/Guzzle uses PHP stream wrappers over openssl instead. `gd` is compiled in, so thumbnailing works with no external ImageMagick.
- **`bin/build.php`** is the binary's entry point: `./wikven php-cli build.php` runs the whole pipeline (install → load WikvenSettings → fetch third-party components → build) by re-invoking the binary once per step. It resolves the executable via `readlink('/proc/self/exe')` (FrankenPHP leaves `PHP_BINARY` empty in CLI mode) and points `SSL_CERT_FILE` at the host CA bundle for InstantCommons/git over HTTPS.
- **`.github/workflows/release-binary.yaml`**: on a published release, builds the binary for `linux/amd64` (ubuntu-latest) and `linux/arm64` (ubuntu-24.04-arm) and attaches each with `gh release upload`.
- **docs**: a *Standalone binary* page, with sidebar and Getting Started links.

This builds on #44 (the `WIKVEN_WORKDIR` + runtime image-backend abstraction).

## Verification

Built the binary locally (442 MB, statically linked) and ran `./wikven php-cli build.php` against `docs/`: MediaWiki installs, WikvenSettings detects the host's image tools (ImageMagick when present, GD + native SVG otherwise), TemplateStyles is git-cloned, and the export completes, output identical to the Docker build (13 pages, 0 thumbnail/TemplateStyles errors, vector-2022). The full FrankenPHP feasibility investigation is in #42.

> [!NOTE]
> macOS and arm-local testing are out of scope here (no free Intel-mac runner; arm64 is built but only validated in CI). Multi-arch/mac signing can follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
