### PR TITLE
feat: export site styles and teal-brand the docs

### DIFF
--- a/docs/MediaWiki:Common.css.wikitext
+++ b/docs/MediaWiki:Common.css.wikitext
@@ -1,0 +1,10 @@
+/* Wikven uses a teal brand colour, so replace the skin's default Wikimedia blue
+ * (the Codex "progressive" colour) with teal. Links and interactive accents read
+ * these tokens, so overriding them recolours them site-wide. */
+:root {
+	--color-progressive: #157f93;
+	--color-progressive--hover: #0f6173;
+	--color-progressive--active: #0c4d5b;
+	--color-progressive--focus: #157f93;
+	--color-link: #157f93;
+}

--- a/maintenance/buildStyles.php
+++ b/maintenance/buildStyles.php
@@ -64,10 +64,36 @@ class BuildStyles extends Maintenance {
 			}
 		}
 
+		$cssDir = "$wgWikvenHtmlDirectory/$wgWikvenStyleDirectory";
+
+		// MediaWiki batches the site styles (MediaWiki:Common.css and the skin's
+		// site CSS) into a single load.php?only=styles link that the static export
+		// drops. Render that module to its own file so rewriteScripts can link it;
+		// an empty result (no MediaWiki:Common.css) is left out.
+		$query = ResourceLoader::makeLoaderQuery(
+			['site.styles'],
+			$wgLanguageCode,
+			$wgDefaultSkin,
+			// user
+			null,
+			// version
+			null,
+			// inDebugMode
+			null,
+			// only
+			'styles'
+		);
+		$context = new Context($resourceLoader, new FauxRequest($query));
+		ob_start();
+		$resourceLoader->respond($context);
+		$siteStyles = ob_get_clean();
+		if (trim($siteStyles) !== '') {
+			file_put_contents("$cssDir/site.styles.css", $siteStyles, LOCK_EX);
+		}
+
 		// The dumped CSS still points icon background-images at the load.php image
 		// endpoint, which 404s on a static host. Dump each referenced image to a
 		// local file and rewrite the url() to it.
-		$cssDir = "$wgWikvenHtmlDirectory/$wgWikvenStyleDirectory";
 		AssetLocalizer::localizeImages(
 			$resourceLoader,
 			$cssDir,

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -35,10 +35,12 @@ class RewriteScripts extends Maintenance {
 	}
 
 	public function execute() {
-		global $wgWikvenHtmlDirectory, $wgWikvenScriptDirectory;
+		global $wgWikvenHtmlDirectory, $wgWikvenScriptDirectory, $wgWikvenStyleDirectory;
 
 		$htmlDir = rtrim($wgWikvenHtmlDirectory, '/');
 		$prefix = './' . rtrim($wgWikvenScriptDirectory, '/');
+		$siteStylesHref = './' . rtrim($wgWikvenStyleDirectory, '/') . '/site.styles.css';
+		$hasSiteStyles = is_file("$htmlDir/site.styles.css") && filesize("$htmlDir/site.styles.css") > 0;
 
 		$rl = MediaWikiServices::getInstance()->getResourceLoader();
 
@@ -99,6 +101,17 @@ class RewriteScripts extends Maintenance {
 				'',
 				$html
 			);
+
+			// The dropped combined link carried the site styles (MediaWiki:Common.css
+			// and the skin's site CSS); buildStyles wrote them to their own file.
+			// Link it last, so it wins the cascade over the skin's defaults.
+			if ($hasSiteStyles) {
+				$html = str_replace(
+					'</head>',
+					'<link rel="stylesheet" href="' . $siteStylesHref . '"></head>',
+					$html
+				);
+			}
 
 			// No logo is configured, so the placeholder "change your logo" asset
 			// would 404. Neutralize its reference (the logo itself is CSS-hidden).


### PR DESCRIPTION
## What

Make **MediaWiki:Common.css / MediaWiki:Vector.css work in the static export**, and use it to give the docs site Wikven's teal brand colour instead of the default Wikimedia blue.

## Why

The export already bundled the site *JavaScript* (MediaWiki:Common.js, via the `site` module), but not the site *styles*. MediaWiki batches MediaWiki:Common.css and the skin's site CSS into a single `load.php?only=styles` link, which `rewriteScripts` dropped as "redundant" — so MediaWiki:Common.css had no effect on the output.

## How

- `buildStyles.php` renders the `site.styles` module to its own `site.styles.css` (skipped when empty).
- `rewriteScripts.php` links it just before `</head>`, after the skin styles, so it wins the cascade.
- `docs/MediaWiki:Common.css` overrides the Codex `--color-progressive` token (`#36c`, the Wikimedia blue) with Wikven teal `#157f93`, recolouring links and interactive accents site-wide.

This is the styles counterpart of the existing Common.js support.

## Verification

Built the docs and confirmed `site.styles.css` is emitted, linked, and contains the teal tokens; in the browser the content links compute to `rgb(21, 127, 147)` (#157f93) and the page renders teal with no console errors (screenshot in the thread). A transient InstantCommons thumbnail hiccup on one rebuild cleared on the next (unrelated to this CSS change). `mago fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
