### PR TITLE
ci: publish nightly binary builds

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -1,0 +1,48 @@
+name: Build binary
+
+# Reusable: build the standalone binary for each architecture and attach it to
+# the given release tag. Called by release-binary.yaml and nightly.yaml.
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: The release tag to upload the binaries to.
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  binary:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: aarch64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write # gh release upload
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # The standalone binary embeds the same MediaWiki + Wikven tree the image
+      # ships, so build that image first, then embed it into a FrankenPHP binary.
+      - name: Build the embedding image
+        run: docker build -t wikven .
+
+      - name: Build the standalone binary
+        run: docker build -f Dockerfile.binary --target export -o type=local,dest=out .
+
+      - name: Name it per architecture
+        run: mv out/wikven "wikven-linux-${{ matrix.arch }}"
+
+      - name: Attach to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: gh release upload "$TAG" "wikven-linux-${{ matrix.arch }}" --clobber

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,42 @@
+name: Nightly binary
+
+# Build the standalone binary from the tip of main every day and publish it to a
+# single rolling "nightly" pre-release, so there is always a stable URL for the
+# latest build: releases/download/nightly/wikven-linux-<arch>.
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # recreate the nightly release + tag
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Re-point the rolling "nightly" pre-release at the current main commit so
+      # the binary job can upload fresh assets to it.
+      - name: Recreate the nightly pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag || true
+          gh release create nightly \
+            --prerelease \
+            --target "$GITHUB_SHA" \
+            --title "Nightly" \
+            --notes "Standalone binaries built from main ($GITHUB_SHA), refreshed daily."
+
+  binary:
+    needs: prepare
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-binary.yaml
+    with:
+      tag: nightly

--- a/.github/workflows/release-binary.yaml
+++ b/.github/workflows/release-binary.yaml
@@ -10,35 +10,8 @@ permissions: {}
 
 jobs:
   binary:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            arch: x86_64
-          - runner: ubuntu-24.04-arm
-            arch: aarch64
-    runs-on: ${{ matrix.runner }}
     permissions:
-      contents: write # gh release upload
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      # The standalone binary embeds the same MediaWiki + Wikven tree the image
-      # ships, so build that image first, then embed it into a FrankenPHP binary.
-      - name: Build the embedding image
-        run: docker build -t wikven .
-
-      - name: Build the standalone binary
-        run: docker build -f Dockerfile.binary --target export -o type=local,dest=out .
-
-      - name: Name it per architecture
-        run: mv out/wikven "wikven-linux-${{ matrix.arch }}"
-
-      - name: Attach to the release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG" "wikven-linux-${{ matrix.arch }}" --clobber
+      contents: write
+    uses: ./.github/workflows/build-binary.yaml
+    with:
+      tag: ${{ github.event.release.tag_name }}

--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -13,6 +13,12 @@ chmod +x wikven
 
 On arm64, use <code>wikven-linux-aarch64</code>.
 
+To track the latest commit on the main branch instead of a tagged release, use the rolling [https://github.com/chaotic-ground/wikven/releases/tag/nightly nightly] build, refreshed daily:
+
+<syntaxhighlight lang="shell">
+curl -L -o wikven https://github.com/chaotic-ground/wikven/releases/download/nightly/wikven-linux-x86_64
+</syntaxhighlight>
+
 == Building a site ==
 
 Put your wikitext and a [[wikven.yaml|.wikven.yaml]] in a <code>src/</code> directory, then build:


### PR DESCRIPTION
## What

Publish a **nightly standalone-binary build** from the tip of `main`, in addition to the per-release binaries (#45).

## How

- **`build-binary.yaml`** (new, reusable): the per-architecture build + `gh release upload`, extracted so it isn't duplicated.
- **`release-binary.yaml`**: refactored to call the reusable workflow (behaviour unchanged, still fires on a published release).
- **`nightly.yaml`** (new): runs daily (and on `workflow_dispatch`); a `prepare` job re-points a rolling `nightly` pre-release at the current `main` commit, then the reusable build attaches fresh `wikven-linux-x86_64` / `wikven-linux-aarch64` assets. This gives a stable URL for the latest build:

  ```
  https://github.com/chaotic-ground/wikven/releases/download/nightly/wikven-linux-x86_64
  ```
- **docs**: the Standalone binary page notes the nightly download.

## Verification

`actionlint` is clean (exit 0) and `zizmor` reports no findings on all three workflows, including the reusable-workflow wiring (`uses: ./.github/workflows/build-binary.yaml`), the matrix, and the `contents: write` permissions. The binary build itself is the same one validated in #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
