### PR TITLE
feat: add a wikven build command to the binary

### DIFF
--- a/Dockerfile.binary
+++ b/Dockerfile.binary
@@ -5,7 +5,7 @@
 # Usage (the wikven image must be built first, e.g. `docker build -t wikven .`):
 #   docker build -f Dockerfile.binary --target export -o type=local,dest=out .
 #   # -> out/wikven, a single static executable. Run it with:
-#   #    WIKVEN_WORKDIR=. ./wikven php-cli build.php
+#   #    WIKVEN_WORKDIR=. ./wikven build
 
 # Stage 1: the app tree to embed = the wikven image + the binary entry point,
 # minus what the build never needs (keeping all locales, so the binary is not
@@ -26,6 +26,11 @@ RUN find /var/www/html -type d -name tests -prune -exec rm -rf {} + \
 FROM dunglas/frankenphp:static-builder-musl AS builder
 WORKDIR /go/src/app
 COPY --from=app /var/www/html ./dist/app
+# A small Caddy module registers the `build` subcommand, so the binary can be run
+# as `./wikven build` instead of `./wikven php-cli build.php`. It is linked into
+# the FrankenPHP binary alongside FrankenPHP's own default Caddy modules.
+COPY caddy /go/wikven-caddy
+ENV SPC_CMD_VAR_FRANKENPHP_XCADDY_MODULES="--with github.com/dunglas/mercure/caddy --with github.com/dunglas/vulcain/caddy --with github.com/dunglas/caddy-cbrotli --with github.com/chaotic-ground/wikven/caddy=/go/wikven-caddy"
 ENV PHP_VERSION=8.3
 ENV PHP_EXTENSIONS="gd,intl,pdo_sqlite,sqlite3,mbstring,dom,xml,simplexml,xmlreader,xmlwriter,fileinfo,iconv,ctype,filter,tokenizer,phar,session,calendar,opcache,openssl,sodium,zlib,bcmath,exif"
 ENV PHP_EXTENSION_LIBS="libpng,libjpeg,freetype,libwebp"

--- a/bin/build.php
+++ b/bin/build.php
@@ -1,8 +1,10 @@
 <?php
 /**
  * Standalone-binary entry point: build the whole static site in one invocation.
+ * The `build` Caddy subcommand (see caddy/) runs this through php-cli, so the
+ * user-facing command is:
  *
- *   WIKVEN_WORKDIR=/path/to/work  ./wikven php-cli build.php
+ *   WIKVEN_WORKDIR=/path/to/work  ./wikven build
  *
  * Reads $WIKVEN_WORKDIR/src (input), writes $WIKVEN_WORKDIR/dist (output), and
  * keeps ephemeral state in $WIKVEN_WORKDIR/.cache. WIKVEN_WORKDIR defaults to the

--- a/caddy/go.mod
+++ b/caddy/go.mod
@@ -1,0 +1,5 @@
+module github.com/chaotic-ground/wikven/caddy
+
+go 1.24
+
+require github.com/caddyserver/caddy/v2 v2.11.4

--- a/caddy/wikven.go
+++ b/caddy/wikven.go
@@ -1,0 +1,37 @@
+// Package wikvencaddy registers a "build" subcommand on the wikven binary, so
+// the static site can be built with `./wikven build` instead of the longer
+// `./wikven php-cli build.php`. It simply re-invokes the binary's embedded
+// build.php through php-cli.
+package wikvencaddy
+
+import (
+	"os"
+	"os/exec"
+
+	caddycmd "github.com/caddyserver/caddy/v2/cmd"
+)
+
+func init() {
+	caddycmd.RegisterCommand(caddycmd.Command{
+		Name:  "build",
+		Usage: " ",
+		Short: "Build the static site from the embedded MediaWiki",
+		Long: "Builds WIKVEN_WORKDIR/src into WIKVEN_WORKDIR/dist " +
+			"(WIKVEN_WORKDIR defaults to the current directory).",
+		Func: func(_ caddycmd.Flags) (int, error) {
+			self, err := os.Executable()
+			if err != nil {
+				return 1, err
+			}
+			cmd := exec.Command(self, "php-cli", "build.php")
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Env = os.Environ()
+			if err := cmd.Run(); err != nil {
+				return 1, err
+			}
+			return 0, nil
+		},
+	})
+}

--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -20,13 +20,13 @@ Put your wikitext and a [[wikven.yaml|.wikven.yaml]] in a <code>src/</code> dire
 <syntaxhighlight lang="shell">
 mkdir -p src
 echo 'Hello, World!' > src/index.wikitext
-./wikven php-cli build.php
+./wikven build
 </syntaxhighlight>
 
 The rendered site is written to <code>dist/</code>. The working directory defaults to the current directory; set <code>WIKVEN_WORKDIR</code> to build a project elsewhere:
 
 <syntaxhighlight lang="shell">
-WIKVEN_WORKDIR=/path/to/project ./wikven php-cli build.php
+WIKVEN_WORKDIR=/path/to/project ./wikven build
 </syntaxhighlight>
 
 The output is the same as the Docker image's: the binary embeds MediaWiki, the bundled extensions and skins, and every interface language.


### PR DESCRIPTION
## What

Replace the awkward `./wikven php-cli build.php` invocation of the [standalone binary](#45) with a clean **`./wikven build`**.

```shell
WIKVEN_WORKDIR=. ./wikven build
```

## Why / how

An embedded FrankenPHP binary only exposes FrankenPHP's own Caddy subcommands (`run`, `php-server`, `php-cli`); there is no way to make `./wikven build` work without registering it. So:

- **`caddy/`** — a small Caddy module registers a `build` subcommand that re-invokes the binary (`os.Executable()` → `php-cli build.php`), forwarding stdio and the environment. `PHP_BINARY` is empty under FrankenPHP CLI, so the binary re-runs itself.
- **`Dockerfile.binary`** — links the module into the binary via the FrankenPHP static builder's `SPC_CMD_VAR_FRANKENPHP_XCADDY_MODULES` (an `xcaddy --with …/wikven/caddy=/go/wikven-caddy` alongside FrankenPHP's default modules).
- **docs** — the Standalone binary page now shows `./wikven build`.

## Verification

Built the binary through the actual `Dockerfile.binary` (the same path CI runs) and confirmed:
- `./wikven help` lists `build   Build the static site from the embedded MediaWiki`.
- `WIKVEN_WORKDIR=… ./wikven build` installs MediaWiki, clones the third-party TemplateStyles, and renders the docs sample end-to-end (`wikven: done -> dist`, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
