### PR TITLE
style: teal visited links and a Vector-style note box

### DIFF
--- a/docs/MediaWiki:Common.css.wikitext
+++ b/docs/MediaWiki:Common.css.wikitext
@@ -7,4 +7,11 @@
 	--color-progressive--active: #0c4d5b;
 	--color-progressive--focus: #157f93;
 	--color-link: #157f93;
+	--color-visited: #0e5f70;
+}
+
+/* Visited links are coloured by a hard-coded a:visited rule in the skin, not the
+ * token above, so recolour them to a darker teal here as well. */
+a:visited {
+	color: #0e5f70;
 }

--- a/docs/Template:note/styles.css.wikitext
+++ b/docs/Template:note/styles.css.wikitext
@@ -1,11 +1,14 @@
 .wikven-note {
-	border: 0.2em solid lightgray;
-	margin: 0.2em 1em;
-	padding: 0.7em;
 	display: flex;
-	column-gap: 0.5em;
+	align-items: center;
+	column-gap: 0.75em;
+	margin: 1em 0;
+	padding: 0.75em 1em;
+	border: 1px solid #c8ccd1;
+	border-radius: 2px;
+	background-color: #f8f9fa;
 }
 
-.wikven-note-text {
-	vertical-align: middle;
+.wikven-note-text p {
+	margin: 0;
 }


### PR DESCRIPTION
## What

Two brand/skin polish fixes on the docs site.

## Visited links → teal

Visited links were still navy. The teal branding (#46) overrode `--color-progressive`/`--color-link`, but the skin colours visited links with a hard-coded `a:visited { color: #0b0080 }` rule that the `--color-visited` token does not drive. So `MediaWiki:Common.css` now recolours `a:visited` to a darker teal (`#0e5f70`), distinct from the brighter unvisited teal. Verified in the browser: a visited link renders the darker teal, not navy.

## Vector-style note box

The `{{note}}` template's box was a plain `0.2em solid lightgray` border. Restyled to match Vector 2022 / Codex: a subtle neutral background (`#f8f9fa`), a thin 1px border (`#c8ccd1`) with a 2px radius, and vertically centered icon/text. Screenshot in thread.

## Verification

Built the docs: 0 thumbnail/TemplateStyles errors, TemplateStyles still applied on 7 pages; screenshots confirm the note box and the visited-link colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
