### PR TITLE
docs: link the Development page from the sidebar

### DIFF
--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -9,5 +9,6 @@
 ** JavaScript|JavaScript
 * References
 ** wikven.yaml|.wikven.yaml
+** Development|Development
 *
 ** helppage|help-mediawiki


### PR DESCRIPTION
## What

Add the **Development** page to the sidebar navigation (`MediaWiki:Sidebar`), under References.

## Why

The Development page (#48) was reachable only by direct URL, it wasn't linked anywhere in the navigation. Comparing the sidebar against the content pages, Development was the only one missing (Getting Started, Standalone binary, Editing sidebar, Images, Skins, JavaScript, and .wikven.yaml are all already linked), so this closes that gap.

## Verification

Built the docs and confirmed `id="n-Development"` appears in the rendered sidebar, under the References section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
