### PR TITLE
feat: upgrade to MediaWiki 1.45

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mediawiki:1.43
+FROM mediawiki:1.45
 
 # composer (and unzip, which composer uses to extract dist archives) so that
 # third-party extensions/skins declared in .wikven.yaml can be installed at build

--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -2,6 +2,7 @@ extensions:
   - SyntaxHighlight_GeSHi
   - ParserFunctions
   - TemplateStyles
+  - Variables
 skins:
   - Vector
 config:
@@ -11,9 +12,9 @@ config:
   WikvenLogos:
     icon: logo.svg
   WikvenRepositories:
-    # TemplateStyles is not bundled in the image; clone it from Git. Its only
-    # Composer dependency (wikimedia/css-sanitizer) already ships in MediaWiki
-    # core, so a plain clone is enough.
-    TemplateStyles:
-      repository: https://github.com/wikimedia/mediawiki-extensions-TemplateStyles.git
-      reference: REL1_43
+    # Variables is not bundled in the image; clone it from Git to show off
+    # third-party fetching. (TemplateStyles, which the templates use, is bundled
+    # in MediaWiki 1.45, so it needs no source here.)
+    Variables:
+      repository: https://github.com/wikimedia/mediawiki-extensions-Variables.git
+      reference: REL1_45

--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -9,7 +9,7 @@ A {{wikven}} build has four moving parts:
 * The '''extension''' (<code>extension.json</code>, <code>includes/</code>). It registers {{wikven}}'s configuration and a few hooks that adapt MediaWiki's output for a static host: hiding the edit/history UI and the sidebar's wiki-only links, swapping footer links for the configured <code>WikvenFooterUrl</code>/<code>WikvenEditUrl</code>/<code>WikvenHistoryUrl</code>, and rewriting internal URLs so they point at <code>.html</code> files instead of <code>index.php?title=</code>.
 * The '''maintenance scripts''' (<code>maintenance/</code>). These are the build pipeline, described below.
 * '''<code>WikvenSettings.php</code>'''. The <code>LocalSettings.php</code> the build runs under: it loads the configuration, detects the image backend, and applies {{wikven}}'s defaults.
-* The '''<code>run</code>''' script and '''<code>Dockerfile</code>'''. They package MediaWiki 1.43 plus the extension into an image whose entry point performs one build.
+* The '''<code>run</code>''' script and '''<code>Dockerfile</code>'''. They package MediaWiki 1.45 plus the extension into an image whose entry point performs one build.
 
 == Building the image ==
 
@@ -17,7 +17,7 @@ A {{wikven}} build has four moving parts:
 docker build --tag wikven .
 </syntaxhighlight>
 
-The <code>Dockerfile</code> is <code>FROM mediawiki:1.43</code>. It adds Composer and unzip (needed when fetching third-party extensions), copies the extension into <code>/var/www/html/extensions/Wikven</code>, copies <code>WikvenSettings.php</code> into the MediaWiki root, and sets the <code>run</code> script as the entry point.
+The <code>Dockerfile</code> is <code>FROM mediawiki:1.45</code>. It adds Composer and unzip (needed when fetching third-party extensions), copies the extension into <code>/var/www/html/extensions/Wikven</code>, copies <code>WikvenSettings.php</code> into the MediaWiki root, and sets the <code>run</code> script as the entry point.
 
 == Running a build ==
 

--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -26,7 +26,7 @@ config:
   WikvenRepositories:
     Example:
       repository: https://github.com/example/Example.git
-      reference: REL1_43
+      reference: REL1_45
 </syntaxhighlight>
 
 == Skin-specific configuration ==

--- a/docs/wikven.yaml.wikitext
+++ b/docs/wikven.yaml.wikitext
@@ -53,12 +53,12 @@ config:
     # 1. A tarball, e.g. from Special:ExtensionDistributor, whose archive already
     #    bundles the extension's dependencies.
     Foo:
-      tarball: https://extdist.wmflabs.org/dist/extensions/Foo-REL1_43-abc1234.tar.gz
+      tarball: https://extdist.wmflabs.org/dist/extensions/Foo-REL1_45-abc1234.tar.gz
     # 2. A Git repository. Add an optional reference (a tag or branch), and
     #    composer: true to run Composer inside the cloned directory.
     Bar:
       repository: https://github.com/example/Bar.git
-      reference: REL1_43
+      reference: REL1_45
       composer: true
     # 3. A Composer package, resolved through MediaWiki's composer.local.json.
     SemanticMediaWiki:
@@ -69,7 +69,7 @@ A name in <code>WikvenRepositories</code> that already exists in the image (a bu
 
 {{note|The build downloads and runs the code you name here, with network access. Only declare sources you trust, and prefer pinning a <code>reference</code> or version.}}
 
-This very site fetches {{ml|Extension:TemplateStyles|TemplateStyles}} this way (see its <code>.wikven.yaml</code>) to style its templates; the notice box above is one example.
+This very site fetches {{ml|Extension:Variables|Variables}} this way (see its <code>.wikven.yaml</code>): {{#vardefine:demo|42}}{{#var:demo}} is rendered by the fetched extension. (Its templates are styled with TemplateStyles, which is bundled in MediaWiki and so needs no source here.)
 
 == Defaults ==
 

--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
 	"license-name": "GPL-3.0-or-later",
 	"type": "other",
 	"requires": {
-		"MediaWiki": ">= 1.37.0"
+		"MediaWiki": ">= 1.43.0"
 	},
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\Wikven\\": "includes/"

--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use FauxRequest;
+use MediaWiki\Request\FauxRequest;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
 

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -2,8 +2,8 @@
 
 namespace MediaWiki\Extension\Wikven\Hooks;
 
-use Html;
-use Skin;
+use MediaWiki\Html\Html;
+use MediaWiki\Skin\Skin;
 
 class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\SkinAddFooterLinksHook {
 	/** @inheritDoc */

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -2,14 +2,14 @@
 
 namespace MediaWiki\Extension\Wikven\Hooks;
 
-use Config;
-use FauxRequest;
-use Html;
+use MediaWiki\Config\Config;
+use MediaWiki\Request\FauxRequest;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
-use OutputPage;
-use Title;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Title\Title;
 
 class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPageAfterGetHeadLinksArrayHook {
 	/** @var Context */

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -2,15 +2,15 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use CommentStoreComment;
-use ContentHandler;
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\ContentHandler;
 use ImportImages;
 use Maintenance;
 use MediaWiki\Revision\SlotRecord;
 use RebuildFileCache;
 use RunJobs;
-use Title;
-use User;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 	? getenv('MW_INSTALL_PATH')

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use FauxRequest;
+use MediaWiki\Request\FauxRequest;
 use Maintenance;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\ResourceLoader\Context;

--- a/maintenance/buildStyles.php
+++ b/maintenance/buildStyles.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use FauxRequest;
+use MediaWiki\Request\FauxRequest;
 use Maintenance;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\ResourceLoader\Context;

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -2,13 +2,13 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use CommentStoreComment;
-use ContentHandler;
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\ContentHandler;
 use Maintenance;
 use MediaWiki\Revision\SlotRecord;
-use StubGlobalUser;
-use Title;
-use User;
+use MediaWiki\StubObject\StubGlobalUser;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
 use WikiRevision;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''


### PR DESCRIPTION
## What

Upgrade the base from **MediaWiki 1.43 → 1.45** (1.45.3, PHP 8.3). "확 올립시다."

## How

**Class namespacing.** MediaWiki 1.44/1.45 removed the deprecated global class aliases (the build died with `Class "Title" not found`). The extension hooks and maintenance scripts now import the namespaced classes:

`MediaWiki\Title\Title`, `MediaWiki\User\User`, `MediaWiki\Content\ContentHandler`, `MediaWiki\CommentStore\CommentStoreComment`, `MediaWiki\Request\FauxRequest`, `MediaWiki\StubObject\StubGlobalUser`, `MediaWiki\Html\Html`, `MediaWiki\Config\Config`, `MediaWiki\Output\OutputPage`, `MediaWiki\Skin\Skin`.

`extension.json` now requires MediaWiki ≥ 1.43 (where these FQNs exist).

**TemplateStyles is now bundled in 1.45** (it wasn't in 1.43), so the docs no longer fetch it. The third-party-fetch dogfood switches to **Variables** (cloned from Git at `REL1_45`), with a live `{{#var}}` example on the .wikven.yaml page so the feature is still demonstrated. Doc version references bumped to 1.45 / REL1_45.

## Verification

The docs build runs **clean on 1.45**: exit 0, 0 thumbnail/TemplateStyles errors, **0 deprecation warnings**, MediaWiki 1.45.3 in the output. Variables is fetched and its `{{#var:demo}}` renders "42"; the note/prevnext/hr templates are styled by the bundled TemplateStyles (7 pages emit scoped CSS). `mago` clean.

> [!NOTE]
> The standalone binary (`Dockerfile.binary`) is `FROM wikven`, so it inherits 1.45 and the same namespaced code; PHP 8.3 still matches the base. It wasn't rebuilt locally here (the static-build infra was cleaned up), CI rebuilds it on the next release/nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
