### PR TITLE
feat: serve logos from a shared upload instead of inlining them per page

### DIFF
--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -171,37 +171,46 @@ foreach ($config['config'] ?? [] as $key => $val) {
 }
 
 // Logos: WikvenLogos mirrors MediaWiki's $wgLogos, except each source is the name
-// of an image file in the source directory rather than a URL. The static export
-// rewrites asset URLs to hashed local files, so there is no stable URL to point
-// $wgLogos at; instead each named file is inlined as a data URI. A value is
-// either a file name, or (like $wgLogos['wordmark'] and ['tagline']) a map with a
-// "src" file name plus extra keys such as width and height.
+// of an image file in the source directory rather than a URL. Those files are
+// uploaded into the File: namespace at build time like any other source image, so
+// each one already has a URL; we point $wgLogos at it. The upload path is
+// predictable because uploads are stored flat (HashedUploadDirectory: false in
+// default.yaml), so the URL can be built here, at config time, before the file is
+// actually uploaded later in the build. The static export then localizes that URL
+// to a single shared file alongside the HTML (storeImages.php), so the logo is not
+// inlined into every page. A value is either a file name, or (like
+// $wgLogos['wordmark'] and ['tagline']) a map with a "src" file name plus extra
+// keys such as width and height.
 if (!empty($wgWikvenLogos) && is_array($wgWikvenLogos)) {
-	$wikvenLogoData = static function ($name) use ($wikvenSrc) {
-		$file = "$wikvenSrc/" . $name;
-		if (!is_file($file)) {
+	// Map a source file name to the URL its upload will have. MediaWiki turns the
+	// file name into a File: title (spaces become underscores, and the first letter
+	// is capitalized unless $wgCapitalLinks is off, as Wikven's default keeps it),
+	// then, with flat storage, serves it from $wgUploadPath/<title>.
+	$wikvenLogoUrl = static function ($name) use ($wikvenSrc) {
+		global $wgUploadPath, $wgScriptPath, $wgCapitalLinks;
+		if (!is_file("$wikvenSrc/" . $name)) {
 			error_log("Wikven: logo file '$name' not found in the source directory");
 			return null;
 		}
-		$mimeTypes = [
-			'svg' => 'image/svg+xml',
-			'png' => 'image/png',
-			'jpg' => 'image/jpeg',
-			'jpeg' => 'image/jpeg',
-			'gif' => 'image/gif',
-			'webp' => 'image/webp',
-			'ico' => 'image/x-icon'
-		];
-		$ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));
-		$mime = $mimeTypes[$ext] ?? 'application/octet-stream';
-		return 'data:' . $mime . ';base64,' . base64_encode(file_get_contents($file));
+		// $wgUploadPath is still its false default this early (MediaWiki resolves it
+		// to "$wgScriptPath/images" later, in Setup.php); resolve it the same way so
+		// the URL matches what the upload, and storeImages.php, will use.
+		$uploadPath =
+			$wgUploadPath !== false && (string)$wgUploadPath !== ''
+				? $wgUploadPath
+				: ( $wgScriptPath ?? '' ) . '/images';
+		$title = str_replace(' ', '_', trim($name));
+		if ($wgCapitalLinks ?? true) {
+			$title = ucfirst($title);
+		}
+		return rtrim((string)$uploadPath, '/') . '/' . $title;
 	};
 
 	$logos = isset($wgLogos) && is_array($wgLogos) ? $wgLogos : [];
 	foreach ($wgWikvenLogos as $key => $value) {
 		if (is_array($value)) {
 			if (isset($value['src'])) {
-				$src = $wikvenLogoData($value['src']);
+				$src = $wikvenLogoUrl($value['src']);
 				if ($src === null) {
 					continue;
 				}
@@ -209,9 +218,9 @@ if (!empty($wgWikvenLogos) && is_array($wgWikvenLogos)) {
 			}
 			$logos[$key] = $value;
 		} else {
-			$data = $wikvenLogoData($value);
-			if ($data !== null) {
-				$logos[$key] = $data;
+			$url = $wikvenLogoUrl($value);
+			if ($url !== null) {
+				$logos[$key] = $url;
 			}
 		}
 	}

--- a/default.yaml
+++ b/default.yaml
@@ -30,6 +30,14 @@ config:
   EnableUploads: true
   FileExtensions: [png, gif, jpg, jpeg, webp, svg]
 
+  # Store uploads flat (images/<name>) instead of in MediaWiki's default
+  # md5-hashed subdirectories (images/a/ab/<name>). The static export has a
+  # single flat upload dir per build, so the hashing buys nothing, and a flat
+  # layout gives every upload a predictable URL. That predictable URL is what
+  # lets WikvenLogos point $wgLogos straight at an uploaded logo file (see
+  # WikvenSettings.php) instead of inlining it into every page.
+  HashedUploadDirectory: false
+
   # Which namespaces count as content. MediaWiki's default is the main namespace
   # alone ([0]); Wikven adds File: (namespace 6) so the file cache exports file
   # description pages too, without dumping every Template:/MediaWiki: page.

--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -65,7 +65,7 @@ The <code>run</code> script:
 
 == Configuration ==
 
-Configuration is layered. <code>default.yaml</code> ships {{wikven}}'s baseline MediaWiki settings; the site's [[wikven.yaml|.wikven.yaml]] is merged on top. <code>WikvenSettings.php</code> reads both with MediaWiki's own YAML settings parser, applies the merged <code>config</code> map, loads the listed <code>extensions</code> and <code>skins</code>, and inlines the <code>WikvenLogos</code>. It also detects the thumbnailing backend at run time, ImageMagick and rsvg when available, otherwise the built-in GD library plus native inline SVG, so the same build works in the image and in a binary that has only GD.
+Configuration is layered. <code>default.yaml</code> ships {{wikven}}'s baseline MediaWiki settings; the site's [[wikven.yaml|.wikven.yaml]] is merged on top. <code>WikvenSettings.php</code> reads both with MediaWiki's own YAML settings parser, applies the merged <code>config</code> map, loads the listed <code>extensions</code> and <code>skins</code>, and points <code>$wgLogos</code> at the uploaded <code>WikvenLogos</code> files. It also detects the thumbnailing backend at run time, ImageMagick and rsvg when available, otherwise the built-in GD library plus native inline SVG, so the same build works in the image and in a binary that has only GD.
 
 == Why these steps exist ==
 

--- a/docs/wikven.yaml.wikitext
+++ b/docs/wikven.yaml.wikitext
@@ -39,7 +39,7 @@ config:
     icon: logo.svg
 </syntaxhighlight>
 
-The values are file names instead of URLs in <code>$wgLogos</code> directly because the static export copies every referenced asset to a local file whose name includes a content hash that is only computed at build time. The logo's final address is therefore not known when you write the configuration, so <code>WikvenLogos</code> names the source file instead and the build inlines it as the logo.
+The values are file names rather than URLs because the file's address is decided by the build, not by you. Each named file is uploaded into the <code>File:</code> namespace like any other source image, and Wikven points <code>$wgLogos</code> at the upload for you, so you only name the file. The export then copies the logo to a single shared file next to the HTML and rewrites the reference to it, the same as for any other image, so the logo is not embedded into every page.
 
 Wikven also ships a small default favicon so browsers do not 404 on <code>/favicon.ico</code>; override it with <code>config.Favicon</code> (a URL or a data URI).
 


### PR DESCRIPTION
## What

Logos were base64-inlined into `$wgLogos`, so the whole logo was embedded into **every page's** `<head>`. This serves them from a single shared file instead, which is exactly what you suggested: store uploads flat so the URL is predictable.

## Why the inlining existed

`WikvenLogos` takes a source **file name**, not a URL, because the asset's final build-time address (`img-<hash>.<ext>`, named by `storeImages.php`) is not knowable when you write the config. So each logo was inlined as a data URI.

## The change

- `default.yaml`: `HashedUploadDirectory: false`. The static export has a single flat upload dir per build, so MediaWiki's md5-hashed `images/a/ab/<name>` layout buys nothing, and a flat `images/<name>` layout gives every upload a **predictable URL**.
- `WikvenSettings.php`: the logo file is already uploaded into `File:` like any other source image, so `WikvenLogos` now points `$wgLogos` at that upload's URL (built at config time from `$wgUploadPath`, resolved the way `Setup.php` does since it is still `false` that early). `storeImages.php` then localizes that URL to one shared file next to the HTML, the same as for any other image, so the logo is no longer duplicated into every page.

`WikvenLogos` config is unchanged (still a source file name); only the mechanism changed. Matters most for raster logos, where the per-page data URI was the largest.

## Verification

End to end on the docs build (`docs/.wikven.yaml` has `WikvenLogos.icon: logo.svg`):
- header logo loads from a single `./img-e90bfaeac7a3.svg` (645 bytes, real SVG), shared across pages;
- the only remaining inline `data:image` is the built-in favicon;
- renders correctly in the browser (screenshot in thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
