### PR TITLE
docs: fix the prev/next chain and polish several pages

### DIFF
--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -35,7 +35,7 @@ The rendered site is written to <code>dist/</code>. The working directory defaul
 WIKVEN_WORKDIR=/path/to/project ./wikven build
 </syntaxhighlight>
 
-The output is the same as the Docker image's: the binary embeds MediaWiki, the bundled extensions and skins, and every interface language.
+The output is the same as the Docker image's: the binary embeds MediaWiki, the bundled extensions and skins, and every interface language, and it reads the same [[wikven.yaml|.wikven.yaml]] layered over {{wikven}}'s defaults.
 
 == Optional host tools ==
 
@@ -44,5 +44,7 @@ The binary renders on its own, but uses these host programs when they are presen
 * '''ImageMagick''' and '''librsvg''' produce higher-quality thumbnails. Without them the binary uses the built-in GD library for raster images and serves SVG inline. See [[Images]].
 * '''git''' is needed only to fetch [[wikven.yaml#WikvenRepositories|third-party extensions and skins]].
 
-{{prevnext|Getting Started}}
+{{note|Fetching over HTTPS, Wikimedia Commons images via InstantCommons and any [[wikven.yaml#WikvenRepositories|third-party extensions or skins]], relies on your system's CA certificates. On a minimal system without them, install your distribution's CA bundle (for example the <code>ca-certificates</code> package). A site with only local content and images needs no network access.}}
+
+{{prevnext|Getting Started|Editing sidebar}}
 {{DISPLAYTITLE:Standalone binary}}

--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -9,7 +9,7 @@ A {{wikven}} build has four moving parts:
 * The '''extension''' (<code>extension.json</code>, <code>includes/</code>). It registers {{wikven}}'s configuration and a few hooks that adapt MediaWiki's output for a static host: hiding the edit/history UI and the sidebar's wiki-only links, swapping footer links for the configured <code>WikvenFooterUrl</code>/<code>WikvenEditUrl</code>/<code>WikvenHistoryUrl</code>, and rewriting internal URLs so they point at <code>.html</code> files instead of <code>index.php?title=</code>.
 * The '''maintenance scripts''' (<code>maintenance/</code>). These are the build pipeline, described below.
 * '''<code>WikvenSettings.php</code>'''. The <code>LocalSettings.php</code> the build runs under: it loads the configuration, detects the image backend, and applies {{wikven}}'s defaults.
-* The '''<code>run</code>''' script and '''<code>Dockerfile</code>'''. They package MediaWiki 1.45 plus the extension into an image whose entry point performs one build.
+* The '''<code>run</code>''' script and '''<code>Dockerfile</code>'''. They package MediaWiki 1.45 plus the extension into an image whose default command runs one build.
 
 == Building the image ==
 
@@ -17,7 +17,7 @@ A {{wikven}} build has four moving parts:
 docker build --tag wikven .
 </syntaxhighlight>
 
-The <code>Dockerfile</code> is <code>FROM mediawiki:1.45</code>. It adds Composer and unzip (needed when fetching third-party extensions), copies the extension into <code>/var/www/html/extensions/Wikven</code>, copies <code>WikvenSettings.php</code> into the MediaWiki root, and sets the <code>run</code> script as the entry point.
+The <code>Dockerfile</code> is <code>FROM mediawiki:1.45</code>. It adds Composer and unzip (needed when fetching third-party extensions), copies the extension into <code>/var/www/html/extensions/Wikven</code>, copies <code>WikvenSettings.php</code> into the MediaWiki root, and sets the <code>run</code> script as the image's default command (<code>CMD</code>).
 
 == Running a build ==
 
@@ -32,7 +32,7 @@ The container mounts the source at <code>/workspace/src</code> and writes the re
 
 The <code>run</code> script:
 
-# installs a throwaway MediaWiki into an SQLite database (no server, no real admin),
+# installs a throwaway MediaWiki into an SQLite database (no web server; the admin account it creates is never used),
 # fetches any third-party extensions and skins (see below),
 # appends <code>require_once 'WikvenSettings.php';</code> to the generated <code>LocalSettings.php</code>,
 # runs the build pipeline,
@@ -73,7 +73,7 @@ A live wiki relies on <code>load.php</code>, an action API, and a database; a st
 
 == Third-party extensions and skins ==
 
-Names in <code>extensions</code>/<code>skins</code> that are not bundled in the image are fetched at build time by <code>maintenance/fetchExtensions.php</code>, from a source declared in [[wikven.yaml#WikvenRepositories|<code>WikvenRepositories</code>]] (a tarball, a Git repository, or a Composer package). This runs after install but before <code>WikvenSettings.php</code> is wired in, so the components are on disk by the time MediaWiki loads them.
+Names in <code>extensions</code>/<code>skins</code> that are not bundled with {{wikven}} are fetched at build time by <code>maintenance/fetchExtensions.php</code>, from a source declared in [[wikven.yaml#WikvenRepositories|<code>WikvenRepositories</code>]] (a tarball, a Git repository, or a Composer package). This runs after install but before <code>WikvenSettings.php</code> is wired in, so the components are on disk by the time MediaWiki loads them.
 
 == Standalone binary ==
 
@@ -84,6 +84,7 @@ The same MediaWiki + {{wikven}} tree is embedded into a single [[Binary|FrankenP
 * <code>lint.yaml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, zizmor).
 * <code>docker-build.yaml</code> builds the image and publishes it to <code>ghcr.io/chaotic-ground/wikven</code> on <code>main</code>.
 * <code>deploy-docs.yaml</code> builds the <code>docs/</code> directory with the image and deploys the result to GitHub Pages, so this site is itself a {{wikven}} build.
-* <code>release-please.yaml</code> manages versioning and releases; the release binaries are attached by the binary build workflow.
+* <code>build-binary.yaml</code> is a reusable workflow that builds the standalone [[Binary|binary]] for each platform. <code>release-binary.yaml</code> calls it on a tagged release to attach the binaries, and <code>nightly.yaml</code> calls it daily to refresh the rolling <code>nightly</code> pre-release.
+* <code>release-please.yaml</code> manages versioning and releases (see below).
 
 Versions follow [https://www.conventionalcommits.org/ Conventional Commits], which release-please uses to generate the changelog and bump the version.

--- a/docs/Editing sidebar.wikitext
+++ b/docs/Editing sidebar.wikitext
@@ -1,7 +1,23 @@
-The sidebar can be configured the same way as on MediaWiki, by editing <code>MediaWiki:Sidebar</code>.
+The navigation sidebar is configured the same way as on MediaWiki, through the <code>MediaWiki:Sidebar</code> system message. Create a <code>MediaWiki:Sidebar.wikitext</code> file in your source directory, alongside your other pages.
 
-{{prevnext|Images}}
+Each top-level <code>*</code> line is a heading, and each <code>**</code> line below it is a link written as <code>page|label</code>. A bare word is looked up as a system message (so <code>mainpage</code> and <code>mainpage-description</code> resolve to the main page and its label). This site's sidebar, for example:
+
+<syntaxhighlight lang="wikitext">
+* navigation
+** mainpage|mainpage-description
+* Docs
+** Getting Started|Getting Started
+** Images|Images
+* References
+** wikven.yaml|.wikven.yaml
+</syntaxhighlight>
+
+== What is removed ==
+
+Some default sidebar blocks need a live wiki, so {{wikven}} drops them from the static export: the '''toolbox''' (What links here, Special pages, Printable version, and so on) and the '''search''' box. The navigation blocks you define in <code>MediaWiki:Sidebar</code> are kept as written.
 
 == See also ==
 
 * {{ml|Manual:Interface/Sidebar}}
+
+{{prevnext|Binary|Images}}

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -47,4 +47,4 @@ EOF
 
 Build again with the same command as before, and the site is titled "My Site".
 
-{{prevnext|Editing sidebar}}
+{{prevnext|Binary}}

--- a/docs/Images.wikitext
+++ b/docs/Images.wikitext
@@ -18,4 +18,4 @@ The thumbnailing backend is detected from the tools present at build time: Image
 
 To give a file its own description page, add a wikitext file named after it in the <code>File:</code> namespace, the same way other namespaced pages are named. For <code>My photo.png</code>, that is <code>File:My photo.png.wikitext</code>.
 
-{{prevnext|Skins}}
+{{prevnext|Editing sidebar|Skins}}

--- a/docs/JavaScript.wikitext
+++ b/docs/JavaScript.wikitext
@@ -1,4 +1,4 @@
-{{wikven}} runs the wiki's own JavaScript in the static export, so site scripts and gadgets work without a live server.
+{{wikven}} bundles the wiki's own JavaScript into the static export at build time, so site scripts and gadgets run without a live server or <code>load.php</code>.
 
 == MediaWiki:Common.js ==
 
@@ -21,4 +21,5 @@ List your gadgets in <code>MediaWiki:Gadgets-definition.wikitext</code>, and put
 
 Only gadgets marked <code>default</code> are loaded: a static site has no logged-in readers to turn other gadgets on. A gadget's own CSS (in the same module) is included, but standalone styles-only gadgets are not yet covered.
 
+{{prevnext|Skins|wikven.yaml}}
 {{DISPLAYTITLE:JavaScript}}

--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -41,4 +41,4 @@ config:
   VectorResponsive: false
 </syntaxhighlight>
 
-{{prevnext|JavaScript}}
+{{prevnext|Images|JavaScript}}

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -1,5 +1,10 @@
-{{wikven}} is a static web page generator that uses {{ml|MediaWiki}},
-the software used on [https://www.wikipedia.org/ Wikipedia].
+{{wikven}} is a static site generator built on {{ml|MediaWiki}}, the software
+behind [https://www.wikipedia.org/ Wikipedia]. It turns a directory of wikitext
+into a plain HTML site you can host anywhere, with no server or database to run.
+This documentation site is itself built with {{wikven}}.
+
+Start with [[Getting Started]], which builds a site two ways: as a Docker image,
+or as a standalone [[Binary|binary]].
 
 == Supported features ==
 
@@ -7,12 +12,14 @@ With {{wikven}}, you can use the following features of MediaWiki.
 
 * {{ml|Wikitext}}
 * {{ml|Help:Templates|Templates}}
-* [[Images|Images]] from Wikimedia Commons or local files
+* [[Images]] from Wikimedia Commons or local files
 * [[JavaScript]] (MediaWiki:Common.js and gadgets)
 * {{ml|Bundled extensions and skins}}
 * Third-party extensions and skins (see [[wikven.yaml|.wikven.yaml]])
 
 == Unsupported features ==
+
+These need a live wiki, so they are not part of the static export:
 
 * Search
 * All special pages

--- a/docs/wikven.yaml.wikitext
+++ b/docs/wikven.yaml.wikitext
@@ -88,3 +88,5 @@ docker run --rm --entrypoint cat ghcr.io/chaotic-ground/wikven extensions/Wikven
 </syntaxhighlight>
 
 It is also in the [https://github.com/chaotic-ground/wikven/blob/main/default.yaml repository].
+
+{{prevnext|JavaScript|Development}}


### PR DESCRIPTION
## What

Navigation fix plus content polish across the docs, working through the docs-audit tasks.

## Navigation (prev/next chain)

The footer prev/next chain was broken: `JavaScript` and `.wikven.yaml` were dead ends with no footer nav, and `Binary` pointed back to `Getting Started` as its "next". It now follows the sidebar's reading order and gives interior pages both arrows:

`Getting Started → Binary → Editing sidebar → Images → Skins → JavaScript → .wikven.yaml → Development`

(`index` is the next-only start; `Development` is the terminal page.)

## Page polish

- **Editing sidebar** was a single sentence. Now documents the `MediaWiki:Sidebar.wikitext` file location, shows an example, and notes the **toolbox** and **search** blocks that the static export drops.
- **Binary**: notes that HTTPS fetches (Commons images via InstantCommons, third-party components) rely on the host's **CA certificates**, and that the binary reads the same `.wikven.yaml` layered over the same defaults as the image.
- **Development**: names the binary CI workflows (`build-binary` / `release-binary` / `nightly`), and corrects the **CMD** wording (the `Dockerfile` uses `CMD`, not an entrypoint) and the throwaway-admin description.
- **index**: warmer intro (what the output is, and that this site dogfoods wikven), a pointer to the two build paths, and a lead-in for the unsupported list; dropped a redundant link label.
- **JavaScript**: ties the intro to the build-time bundling.
- Consistency: "not bundled with wikven" rather than "in the image", since the fetch applies to the binary too.

## Verification

Built the docs; every page renders, the rendered prev/next chain matches the order above, and the new Editing sidebar and index pages look right (screenshots in thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
