### PR TITLE
docs: swap Variables for TabberNeue and tab the build examples

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -2,7 +2,7 @@ extensions:
   - SyntaxHighlight_GeSHi
   - ParserFunctions
   - TemplateStyles
-  - Variables
+  - TabberNeue
 skins:
   - Vector
 config:
@@ -12,9 +12,9 @@ config:
   WikvenLogos:
     icon: logo.svg
   WikvenRepositories:
-    # Variables is not bundled in the image; clone it from Git to show off
+    # TabberNeue is not bundled in the image; clone it from Git to show off
     # third-party fetching. (TemplateStyles, which the templates use, is bundled
     # in MediaWiki 1.45, so it needs no source here.)
-    Variables:
-      repository: https://github.com/wikimedia/mediawiki-extensions-Variables.git
-      reference: REL1_45
+    TabberNeue:
+      repository: https://github.com/StarCitizenTools/mediawiki-extensions-TabberNeue.git
+      reference: v4.0.0

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -15,22 +15,23 @@ mkdir src
 echo 'Hello, World!' > src/index.wikitext
 </syntaxhighlight>
 
-Then build the site. The rendered pages are written to <code>dist/</code>.
+Then build the site. The rendered pages are written to <code>dist/</code>. Pick the tab for how you run {{wikven}}:
 
-; With Docker
-: mount the source and output directories into the container:
+<tabber>
+|-|Docker=
+Mount the source and output directories into the container:
 <syntaxhighlight lang="shell">
 docker run --rm \
   -v "$(pwd)/src:/workspace/src" \
   -v "$(pwd)/dist:/workspace/dist" \
   ghcr.io/chaotic-ground/wikven
 </syntaxhighlight>
-
-; With the binary
-: run it in the directory that holds <code>src/</code> (see [[Binary]] to download it):
+|-|Binary=
+Run it in the directory that holds <code>src/</code> (see [[Binary]] to download it):
 <syntaxhighlight lang="shell">
 ./wikven build
 </syntaxhighlight>
+</tabber>
 
 Open <code>dist/index.html</code> in your browser.
 

--- a/docs/wikven.yaml.wikitext
+++ b/docs/wikven.yaml.wikitext
@@ -73,7 +73,7 @@ Each method needs a host tool present at build time: <code>tarball</code> uses <
 
 {{note|The build downloads and runs the code you name here, with network access. Only declare sources you trust, and prefer pinning a <code>reference</code> or version.}}
 
-This very site fetches {{ml|Extension:Variables|Variables}} this way (see its <code>.wikven.yaml</code>): {{#vardefine:demo|42}}{{#var:demo}} is rendered by the fetched extension. (Its templates are styled with TemplateStyles, which is bundled in MediaWiki and so needs no source here.)
+This very site fetches {{ml|Extension:TabberNeue|TabberNeue}} this way (see its <code>.wikven.yaml</code>): the tabbed Docker/binary command examples on [[Getting Started]] are rendered by the fetched extension. (TemplateStyles, used by this site's templates, is bundled in MediaWiki and so needs no source here.)
 
 == Defaults ==
 


### PR DESCRIPTION
## Summary

Replaces the **Variables** extension with **TabberNeue** as the docs site's third-party-fetch demo, and uses TabberNeue to present the Docker and binary build commands as tabs.

## Changes

- **`docs/.wikven.yaml`** — drop `Variables`, add `TabberNeue`. Fetched from `StarCitizenTools/mediawiki-extensions-TabberNeue` pinned to `v4.0.0` (the canonical maintained repo; TabberNeue isn't on the Wikimedia mirror Variables used, and v4.0.0 requires MediaWiki ≥ 1.43, compatible with this project's 1.45).
- **`docs/Getting Started.wikitext`** — fold the parallel "With Docker" / "With the binary" command blocks into a `<tabber>` with **Docker** and **Binary** tabs.
- **`docs/wikven.yaml.wikitext`** — point the third-party-fetch example at TabberNeue and the tabbed examples, replacing the old inline `{{#var:}}` demo.

## Notes

- The **Binary** page is left binary-only on purpose — its premise is "build without Docker," so the docker/binary tabs live only on Getting Started, where both command forms genuinely appear side by side.
- Not yet built/rendered locally (needs the Docker image or binary). Happy to verify the tabs render in the exported HTML if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)