### PR TITLE
fix: make the main page configurable and fail if it was not imported

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -56,6 +56,10 @@
 			"value": "/workspace/src",
 			"description": "Path to the source directory where wikitext files are"
 		},
+		"WikvenMainPage": {
+			"value": "index",
+			"description": "Title of the page used as the wiki's main page, i.e. the static site root (written as <value>.html). Must be an imported page."
+		},
 		"WikvenHtmlDirectory": {
 			"value": "/workspace/dist",
 			"description": "Path to the dist directory of HTML files."

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -45,6 +45,7 @@ class Build extends Maintenance {
 
 		$this->importImages("$ip/maintenance/importImages.php");
 		$this->step(ImportWikitext::class, "$own/importWikitext.php");
+		$this->assertMainPageExists();
 		$this->step(RunJobs::class, "$ip/maintenance/runJobs.php");
 		$this->step(RebuildFileCache::class, "$ip/maintenance/rebuildFileCache.php", ['overwrite' => true]);
 		$this->step(BuildStyles::class, "$own/buildStyles.php");
@@ -85,7 +86,9 @@ class Build extends Maintenance {
 	}
 
 	/**
-	 * Point the wiki's main page at the imported "index" article.
+	 * Point the wiki's main page at the configured article ($wgWikvenMainPage,
+	 * "index" by default). The article itself is imported afterwards; see
+	 * assertMainPageExists().
 	 */
 	private function setMainPage() {
 		$title = Title::newFromText('MediaWiki:Mainpage');
@@ -93,8 +96,25 @@ class Build extends Maintenance {
 		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
 
 		$updater = $page->newPageUpdater($user);
-		$updater->setContent(SlotRecord::MAIN, ContentHandler::makeContent('index', $title));
+		$content = ContentHandler::makeContent($GLOBALS['wgWikvenMainPage'], $title);
+		$updater->setContent(SlotRecord::MAIN, $content);
 		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Set the main page'));
+	}
+
+	/**
+	 * Fail the build if the configured main page was not imported. Without this
+	 * the main page points at a non-existent article, so the static host serves
+	 * no page at the site root while the build otherwise reports success.
+	 */
+	private function assertMainPageExists() {
+		$name = $GLOBALS['wgWikvenMainPage'];
+		$title = Title::newFromText($name);
+		if (!$title || !$title->exists()) {
+			$this->fatalError(
+				"Wikven: the main page '$name' was not imported. Add a source file for it "
+				. "(e.g. '$name.wikitext') or set \$wgWikvenMainPage to an imported page."
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem (#65)
`maintenance/build.php` hardcoded the main page to the article `index` and never verified it was imported. A source tree without an `index` page produces a wiki whose `MediaWiki:Mainpage` points at a non-existent article — the static host serves nothing at the site root, yet the build reports success.

## Fix
- Add a `WikvenMainPage` config var (default `index`) and use it in `setMainPage()` instead of the hardcoded string.
- After import, `assertMainPageExists()` calls `fatalError` if the configured main page does not exist, so a broken site root fails loudly instead of silently.

The check runs right after `importWikitext` (before the expensive dump steps), so it fails fast.

## Verify
- `php -l`, `mago format`, `biome` (extension.json), and JSON validity all pass.
- The docs build is unaffected (`docs/index.wikitext` exists → page `index` is imported).

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)