### PR TITLE
fix: clear the output directory before each build

### DIFF
--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -41,6 +41,7 @@ class Build extends Maintenance {
 		$ip = $GLOBALS['IP'];
 		$own = __DIR__;
 
+		$this->clearOutputDirectory();
 		$this->setMainPage();
 
 		$this->importImages("$ip/maintenance/importImages.php");
@@ -53,6 +54,32 @@ class Build extends Maintenance {
 		$this->step(RewriteScripts::class, "$own/rewriteScripts.php");
 		$this->step(StoreImages::class, "$own/storeImages.php");
 		$this->step(Rename::class, "$own/rename.php");
+	}
+
+	/**
+	 * Empty the output directory so each build starts from a clean slate. The
+	 * dump/rewrite steps edit HTML in place and rename files, so output left by
+	 * an earlier run into a persistent (e.g. mounted) dist would otherwise
+	 * accumulate: orphaned renamed pages, doubly-rewritten image references, and
+	 * never-collected img-* files. The directory itself is kept (it may be a
+	 * mount point); only its contents are removed.
+	 */
+	private function clearOutputDirectory() {
+		$dir = rtrim($GLOBALS['wgWikvenHtmlDirectory'], '/');
+		if ($dir === '' || !is_dir($dir)) {
+			return;
+		}
+		$entries = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($entries as $entry) {
+			if ($entry->isDir()) {
+				rmdir($entry->getPathname());
+			} else {
+				unlink($entry->getPathname());
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Problem (#64)
The build was designed to be re-run, but `dist/` was never cleared. The in-place rewrite/rename steps assume a fresh tree:
- `storeImages.php` rewrites `<img src>` to `./img-<hash>` and re-saves; on a second run the HTML already contains `./img-*`, and `img-*` files accumulate uncollected.
- `rename.php` renamed `ns6%3AFoo.html` → `File:Foo.html` last run; the next run regenerates `ns6%3A...` alongside the stale `File:...`, leaving orphans.

Net: repeated builds into a persistent/mounted `dist/` grow a partly-stale tree while reporting success.

## Fix
Empty the configured output directory (`$wgWikvenHtmlDirectory`) at the start of `maintenance/build.php`. Both entry points (`run` for Docker and `bin/build.php` for the binary) invoke this orchestrator, so the single fix covers both. The directory itself is preserved (it may be a mount point) — only its contents are removed (files then dirs, child-first).

## Verify
- `php -l` and `mago format` pass.
- Exercised the clear logic on a fixture dir with nested subdirs and `img-*` files: directory kept, fully emptied.

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)