### PR TITLE
fix: make edit/history links correct for all valid titles

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -77,10 +77,12 @@
 			"description": "Url that is added as a footer item."
 		},
 		"WikvenEditUrl": {
-			"value": ""
+			"value": "",
+			"description": "URL template for the per-page \"Edit\" link. $1 is replaced with the page's percent-encoded source file name (e.g. \"Getting Started.wikitext\", \"MediaWiki:Common.css\"). Empty disables the link."
 		},
 		"WikvenHistoryUrl": {
-			"value": ""
+			"value": "",
+			"description": "URL template for the per-page \"View history\" link. $1 is replaced with the page's percent-encoded source file name, as for WikvenEditUrl. Empty disables the link."
 		},
 		"WikvenLogos": {
 			"value": [],

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -56,23 +56,34 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 
 		global $wgWikvenEditUrl, $wgWikvenHistoryUrl;
 		$name = Title::makeName($title->getNamespace(), $title->getDBkey());
-		if (preg_match('/action=([^&]+)/', $query, $matches)) {
-			$action = $matches[1];
-			// $1 is the source filename the page imported from (e.g.
-			// "Getting Started.wikitext" or "MediaWiki:Common.css"), so the link
-			// lands on the file to edit rather than the rendered page.
-			if ($action === 'edit' && $wgWikvenEditUrl) {
-				$file = str_replace('_', '%20', SourceFile::titleToFilename($name));
-				$url = str_replace('$1', $file, $wgWikvenEditUrl);
-			} elseif ($action === 'history' && $wgWikvenHistoryUrl) {
-				$file = str_replace('_', '%20', SourceFile::titleToFilename($name));
-				$url = str_replace('$1', $file, $wgWikvenHistoryUrl);
-			} else {
-				$url = "./$name.html";
-			}
+		// Parse the query into name=>value pairs rather than substring-matching
+		// "action=", which would also fire on e.g. "veaction=edit".
+		$action = wfCgiToArray($query)['action'] ?? null;
+		// For edit/history, $1 is the page's source filename, so the link lands
+		// on the file to edit rather than the rendered page.
+		if ($action === 'edit' && $wgWikvenEditUrl) {
+			$url = str_replace('$1', $this->sourceFileParam($title), $wgWikvenEditUrl);
+		} elseif ($action === 'history' && $wgWikvenHistoryUrl) {
+			$url = str_replace('$1', $this->sourceFileParam($title), $wgWikvenHistoryUrl);
 		} else {
 			$url = "./$name.html";
 		}
+	}
+
+	/**
+	 * The source file a page imported from, percent-encoded for use as the $1 in
+	 * WikvenEditUrl/WikvenHistoryUrl. Built from the title text (spaces, not the
+	 * DB key's underscores) so it matches the on-disk file name, then encoded so
+	 * characters legal in a title but unsafe in a URL path (spaces, '#', '?',
+	 * '%', non-ASCII) cannot break or truncate the link. The subpage separator
+	 * '/' and the namespace separator ':' are kept readable.
+	 *
+	 * @param Title $title
+	 * @return string
+	 */
+	private function sourceFileParam($title) {
+		$file = SourceFile::titleToFilename($title->getPrefixedText());
+		return strtr(rawurlencode($file), ['%2F' => '/', '%3A' => ':']);
 	}
 
 	/** @inheritDoc */

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -41,6 +41,18 @@ class ImportWikitext extends Maintenance {
 				continue;
 			}
 
+			// The static export derives a page's edit/history link filename from
+			// its title. If the title does not round-trip back to this source
+			// file name (MediaWiki normalised it), those links would 404; warn so
+			// the author can rename the file to an already-normalised title.
+			$relative = substr($filename, strlen($sourceDirectory) + 1);
+			if (SourceFile::titleToFilename($title->getPrefixedText()) !== $relative) {
+				$this->output(
+					"Warning: '$relative' imports as page '{$title->getPrefixedText()}'; "
+					. "edit/history links may not resolve back to the file.\n"
+				);
+			}
+
 			$text = file_get_contents($filename);
 			$content = ContentHandler::makeContent($text, $title);
 


### PR DESCRIPTION
## Problem (#67)
1. **Unanchored action match** (`Main.php`): `preg_match('/action=([^&]+)/', ...)` fires on any substring, so a VisualEditor `veaction=edit` link was misread as `action=edit`.
2. **Insufficient escaping**: the source filename was spliced into the `$1` URL template after only `_`→`%20`, leaving `#`, `?`, `&`, `%`, and non-ASCII raw. Titles like `C# (programming)`, `Q&A`, or `Foo?bar` produced truncated/malformed links.
3. Source files whose name doesn't round-trip from the page title yield edit/history links that 404, with no warning.
4. `$1` was undocumented.

## Fix
- Parse the query with `wfCgiToArray()` and read the `action` key (no substring false-match).
- Add `sourceFileParam()`: build the filename from the title text (spaces, matching the on-disk file) and `rawurlencode()` it, keeping `/` (subpages) and `:` (namespace) readable. Every title-legal-but-URL-unsafe character is now encoded.
- Warn at import time when a source filename doesn't round-trip from its title.
- Document the `$1` placeholder on `WikvenEditUrl`/`WikvenHistoryUrl` in `extension.json`.

## Verify
Encoding (no regression for the live docs):
```
Getting Started.wikitext  -> Getting%20Started.wikitext
MediaWiki:Common.css      -> MediaWiki:Common.css          (unchanged)
Template:note/styles.css  -> Template:note/styles.css      (unchanged)
Q&A.wikitext              -> Q%26A.wikitext
C# (programming).wikitext -> C%23%20%28programming%29.wikitext
Über.wikitext             -> %C3%9Cber.wikitext
```
`php -l`, `mago format`, `biome` (extension.json) all pass.

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)