### PR TITLE
test: add PHPUnit tests and a functional CI workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,68 @@
+name: Test
+
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  # Compile the Caddy plugin so a Go build error is caught on the PR rather than
+  # only later, inside the release/nightly binary build.
+  caddy:
+    runs-on: ubuntu-latest
+    env:
+      # No go.sum is committed yet (a separate hardening task), so let go resolve
+      # and record modules on the fly rather than requiring a pinned sum.
+      GOFLAGS: -mod=mod
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "stable"
+          cache: false
+      - run: go build ./...
+        working-directory: caddy
+      - run: go vet ./...
+        working-directory: caddy
+
+  # Run the extension's PHPUnit tests against a real MediaWiki, matching the
+  # 1.45 base image the build ships on.
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out MediaWiki core
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: wikimedia/mediawiki
+          ref: REL1_45
+          path: mediawiki
+          persist-credentials: false
+      - name: Check out Wikven into the extension tree
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          path: mediawiki/extensions/Wikven
+          persist-credentials: false
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: "8.3"
+          extensions: mbstring, intl, calendar, sqlite3, pdo_sqlite, gd, dom, xml, fileinfo
+          tools: composer
+      - name: Install MediaWiki dependencies
+        working-directory: mediawiki
+        run: composer install --no-interaction --no-progress
+      - name: Install MediaWiki (SQLite)
+        working-directory: mediawiki
+        run: |
+          mkdir -p "$RUNNER_TEMP/wikidb"
+          php maintenance/run.php install \
+            --dbtype=sqlite --dbpath="$RUNNER_TEMP/wikidb" \
+            --scriptpath='' \
+            --pass=adminpassword \
+            TestWiki Admin
+      - name: Enable Wikven
+        working-directory: mediawiki
+        run: echo "wfLoadExtension( 'Wikven' );" >> LocalSettings.php
+      - name: Run PHPUnit
+        working-directory: mediawiki
+        run: composer phpunit:entrypoint -- extensions/Wikven/tests/phpunit/

--- a/mago.toml
+++ b/mago.toml
@@ -8,7 +8,7 @@
 php-version = "8.1"
 
 [source]
-paths = ["includes", "maintenance", "WikvenSettings.php"]
+paths = ["includes", "maintenance", "tests", "WikvenSettings.php"]
 
 [formatter]
 print-width = 120

--- a/tests/phpunit/integration/SourceFileTest.php
+++ b/tests/phpunit/integration/SourceFileTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\SourceFile;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\SourceFile
+ */
+class SourceFileTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * Only titles whose content model core resolves without a third-party
+	 * extension are used here (.css/.js in NS_MEDIAWIKI, plain wikitext, images),
+	 * so the test does not depend on TemplateStyles/Scribunto being installed.
+	 *
+	 * @dataProvider providePageFiles
+	 */
+	public function testIsPageFile(string $relativePath, bool $expected) {
+		$this->assertSame($expected, SourceFile::isPageFile($relativePath));
+	}
+
+	public static function providePageFiles() {
+		return [
+			'wikitext page' => ['Getting Started.wikitext', true],
+			'css page' => ['MediaWiki:Common.css', true],
+			'js page' => ['MediaWiki:Common.js', true],
+			'image binary' => ['Bakery oven.jpg', false],
+			'png asset' => ['logo.png', false],
+			'config file' => ['.wikven.yaml', false]
+		];
+	}
+
+	/**
+	 * filenameToTitle() and titleToFilename() must be inverses, so the edit and
+	 * history links the static export derives from a page title resolve back to
+	 * the source file the page was imported from.
+	 *
+	 * @dataProvider provideRoundTrip
+	 */
+	public function testFilenameRoundTrip(string $filename) {
+		$title = SourceFile::filenameToTitle($filename);
+		$this->assertSame($filename, SourceFile::titleToFilename($title));
+	}
+
+	public static function provideRoundTrip() {
+		return [
+			'plain page' => ['Getting Started.wikitext'],
+			'css page keeps its extension' => ['MediaWiki:Common.css'],
+			'js page keeps its extension' => ['MediaWiki:Common.js'],
+			'file description page' => ['File:Bakery oven.jpg.wikitext'],
+			'dotted title that is not a content model' => ['wikven.yaml.wikitext']
+		];
+	}
+}

--- a/tests/phpunit/unit/SourceFileTest.php
+++ b/tests/phpunit/unit/SourceFileTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\SourceFile;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\SourceFile::filenameToTitle
+ */
+class SourceFileTest extends MediaWikiUnitTestCase {
+	/**
+	 * filenameToTitle is pure string handling (it only strips the ".wikitext"
+	 * marker), so it is exercised here without the content-model registry that
+	 * isPageFile()/titleToFilename() need; those are covered by the integration
+	 * test.
+	 *
+	 * @dataProvider provideFilenames
+	 */
+	public function testFilenameToTitle(string $relativePath, string $expected) {
+		$this->assertSame($expected, SourceFile::filenameToTitle($relativePath));
+	}
+
+	public static function provideFilenames() {
+		return [
+			'wikitext marker stripped' => ['Getting Started.wikitext', 'Getting Started'],
+			'nested wikitext marker' => ['File:Bakery oven.jpg.wikitext', 'File:Bakery oven.jpg'],
+			'content extension kept' => ['MediaWiki:Common.css', 'MediaWiki:Common.css'],
+			'nested content extension kept' => ['Template:Note/styles.css', 'Template:Note/styles.css'],
+			'only the trailing marker is stripped' => ['wikven.yaml.wikitext', 'wikven.yaml']
+		];
+	}
+}


### PR DESCRIPTION
## Problem (#63)
- `extension.json` declared `TestAutoloadNamespaces` but there was **no `tests/` tree** — dead config, zero behavioural coverage.
- The **Caddy plugin was never compiled in PR CI** — Go errors only surfaced in the release/nightly binary build, after merge.

## Changes
- **Tests** for `SourceFile` (the file↔page mapping):
  - `tests/phpunit/unit/SourceFileTest.php` — pure `filenameToTitle()`.
  - `tests/phpunit/integration/SourceFileTest.php` — `isPageFile()` and the `filenameToTitle()`↔`titleToFilename()` round-trip, using only content models core resolves (so no dependency on TemplateStyles/Scribunto being installed).
- **`.github/workflows/test.yaml`** with two jobs:
  - `caddy` — `go build` + `go vet` of the plugin on every PR (the most concrete stated gap).
  - `phpunit` — checks out MediaWiki `REL1_45`, installs on SQLite, enables Wikven, runs the extension tests.
- Add `tests/` to mago's source paths so test code is linted like the rest.

## Scope
Committing a pinned `go.sum` and digest-pinning base images is deferred to the reproducibility task (#68); the `caddy` job uses `-mod=mod` so it compiles without a committed sum.

## Verify (local)
- `mago format` (now incl. `tests/`), `php -l`, and the workflow YAML all pass.
- `cd caddy && GOFLAGS=-mod=mod go build ./... && go vet ./...` succeeds.

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)