### PR TITLE
fix: small build-script and config papercuts

### DIFF
--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -141,7 +141,7 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 		if (!is_dir($path)) {
 			mkdir($path, 0777, true);
 		}
-		if (!file_exists("$path/$name")) {
+		if (!file_exists("$path/$name.css")) {
 			touch("$path/$name.css");
 		}
 	}

--- a/mago.toml
+++ b/mago.toml
@@ -4,7 +4,8 @@
 # which tracks how far this configuration is from a zero diff against
 # MediaWiki core and lists the differences that cannot be configured away.
 
-# The mediawiki:1.43 base image ships PHP 8.1.
+# MediaWiki 1.45 (the base image, see Dockerfile) requires PHP 8.1+, so lint
+# against 8.1 as the floor even though the shipped binary runs a newer PHP.
 php-version = "8.1"
 
 [source]

--- a/run
+++ b/run
@@ -2,8 +2,9 @@
 set -euo pipefail; IFS=$'\n\t'
 
 # Source input and rendered output live under one working dir, matching
-# WikvenSettings.php. Defaults to /workspace, the path the image mounts.
-WIKVEN_WORKDIR="${WIKVEN_WORKDIR:-/workspace}"
+# WikvenSettings.php. Defaults to /workspace, the path the image mounts. Export
+# it so the PHP maintenance children (which read it via getenv) see any override.
+export WIKVEN_WORKDIR="${WIKVEN_WORKDIR:-/workspace}"
 
 cd /var/www/html
 
@@ -21,7 +22,10 @@ php maintenance/run.php install \
 # while they are still being fetched).
 php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/fetchExtensions.php
 
-echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
+# Wire in WikvenSettings, but only once: a persistent/mounted install tree would
+# otherwise collect a duplicate require_once on every run.
+grep -qF "require_once 'WikvenSettings.php';" LocalSettings.php \
+  || echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
 
 php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/build.php
 rm -rf "$WIKVEN_WORKDIR/dist/history/"


### PR DESCRIPTION
## Problem (#70)
A handful of small, independent issues found during review.

## Fixes
- **`run` doesn't export `WIKVEN_WORKDIR`** — it was a plain shell var, so PHP children reading it via `getenv()` never saw an override (they fell back to `/workspace`). Now `export`ed.
- **`run` appends `require_once` unguarded** — re-running in a persistent/mounted tree collected duplicates. Now guarded with a `grep -qF` check.
- **`Main.php` touch guard tested the wrong path** — `if (!file_exists("$path/$name"))` but `touch("$path/$name.css")`, so the guard never matched its target. Now checks `$name.css`.
- **`mago.toml` stale comment** — said "mediawiki:1.43" while the Dockerfile is 1.45; corrected and explained why 8.1 is the lint floor.

The fifth item in the issue (missing `WikvenEditUrl`/`WikvenHistoryUrl` descriptions) was already addressed in #73.

## Verify
`bash -n run`, `php -l`, and `mago format` pass.

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)