### PR TITLE
refactor: use native PHP types instead of redundant doc comments

### DIFF
--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -20,13 +20,16 @@ use MediaWiki\ResourceLoader\ResourceLoader;
  */
 class AssetLocalizer {
 	/**
-	 * @param ResourceLoader $rl
 	 * @param string $dir Directory the files live in and where images are dumped.
 	 * @param string[] $files Absolute paths of CSS/JS files to rewrite in place.
-	 * @param string $lang
-	 * @param string $skin
 	 */
-	public static function localizeImages(ResourceLoader $rl, $dir, array $files, $lang, $skin) {
+	public static function localizeImages(
+		ResourceLoader $rl,
+		string $dir,
+		array $files,
+		string $lang,
+		string $skin
+	): void {
 		$mwRoot = rtrim((string)( $GLOBALS['IP'] ?? '' ), '/');
 		$map = [];
 		foreach ($files as $file) {
@@ -76,14 +79,16 @@ class AssetLocalizer {
 	/**
 	 * Dump a single ResourceLoader image-endpoint URL to a local file.
 	 *
-	 * @param ResourceLoader $rl
 	 * @param string $url Decoded /load.php?...image=... reference.
-	 * @param string $dir
-	 * @param string $lang
-	 * @param string $skin
 	 * @return string|null Relative url() target (./img-*.svg), or null if not an image.
 	 */
-	private static function dumpRlImage(ResourceLoader $rl, $url, $dir, $lang, $skin) {
+	private static function dumpRlImage(
+		ResourceLoader $rl,
+		string $url,
+		string $dir,
+		string $lang,
+		string $skin
+	): ?string {
 		$qs = parse_url($url, PHP_URL_QUERY);
 		if (!$qs) {
 			return null;
@@ -125,12 +130,10 @@ class AssetLocalizer {
 	 * Copy a direct asset path (e.g. /skins/Vector/.../foo.svg) out of the
 	 * MediaWiki install into the output directory.
 	 *
-	 * @param string $mwRoot
 	 * @param string $path Absolute web path (with leading slash, no query).
-	 * @param string $dir
 	 * @return string|null Relative url() target, or null if the file is missing.
 	 */
-	private static function copyAsset($mwRoot, $path, $dir) {
+	private static function copyAsset(string $mwRoot, string $path, string $dir): ?string {
 		$src = $mwRoot . $path;
 		if (!is_readable($src)) {
 			return null;

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -13,22 +13,14 @@ use MediaWiki\Title\Title;
 use MediaWiki\Extension\Wikven\SourceFile;
 
 class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPageAfterGetHeadLinksArrayHook {
-	/** @var Context */
-	private $rlClientContext;
+	private ?Context $rlClientContext = null;
 
-	/**
-	 * @var string The path to the directory contains html files.
-	 */
-	private $htmlDirectory;
+	/** The directory the HTML files are written to. */
+	private string $htmlDirectory;
 
-	/**
-	 * @var string The path to the directory contains style files.
-	 */
-	private $styleDirectory;
+	/** The directory the style files are written to, relative to the HTML one. */
+	private string $styleDirectory;
 
-	/**
-	 * @param Config $config
-	 */
 	public function __construct(Config $config) {
 		$this->htmlDirectory = $config->get('WikvenHtmlDirectory');
 		$this->styleDirectory = $config->get('WikvenStyleDirectory');
@@ -77,11 +69,8 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 	 * characters legal in a title but unsafe in a URL path (spaces, '#', '?',
 	 * '%', non-ASCII) cannot break or truncate the link. The subpage separator
 	 * '/' and the namespace separator ':' are kept readable.
-	 *
-	 * @param Title $title
-	 * @return string
 	 */
-	private function sourceFileParam($title) {
+	private function sourceFileParam(Title $title): string {
 		$file = SourceFile::titleToFilename($title->getPrefixedText());
 		return strtr(rawurlencode($file), ['%2F' => '/', '%3A' => ':']);
 	}
@@ -125,10 +114,7 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 		}
 	}
 
-	/**
-	 * @param string $name
-	 */
-	private function addStyleToList($name) {
+	private function addStyleToList(string $name): void {
 		if (MW_ENTRY_POINT != 'cli') {
 			return;
 		}
@@ -146,11 +132,7 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 		}
 	}
 
-	/**
-	 * @param OutputPage $output
-	 * @return Context
-	 */
-	private function getRlClientContext($output) {
+	private function getRlClientContext(OutputPage $output): Context {
 		if (!$this->rlClientContext) {
 			$query = ResourceLoader::makeLoaderQuery(
 				// modules; not relevant

--- a/includes/SourceFile.php
+++ b/includes/SourceFile.php
@@ -31,13 +31,11 @@ class SourceFile {
 	private const MARKER = 'wikitext';
 
 	/**
-	 * Whether a file under the source directory is a page to import (as opposed
-	 * to an asset like an image or the .wikven.yaml config).
-	 *
-	 * @param string $relativePath Path relative to the source directory.
-	 * @return bool
+	 * Whether a file under the source directory (given by its path relative to
+	 * it) is a page to import, as opposed to an asset like an image or the
+	 * .wikven.yaml config.
 	 */
-	public static function isPageFile($relativePath) {
+	public static function isPageFile(string $relativePath): bool {
 		return str_ends_with($relativePath, '.' . self::MARKER) || self::titleHasOwnContentModel($relativePath);
 	}
 
@@ -46,11 +44,8 @@ class SourceFile {
 	 * drop the ".wikitext" marker if present, otherwise keep the path verbatim
 	 * because the title carries its own content model. A nested file becomes a
 	 * subpage, so "Template:Foo/styles.css" imports as "Template:Foo/styles.css".
-	 *
-	 * @param string $relativePath
-	 * @return string
 	 */
-	public static function filenameToTitle($relativePath) {
+	public static function filenameToTitle(string $relativePath): string {
 		$suffix = '.' . self::MARKER;
 		if (str_ends_with($relativePath, $suffix)) {
 			return substr($relativePath, 0, -strlen($suffix));
@@ -62,11 +57,8 @@ class SourceFile {
 	 * Map a page title back to its source path (the inverse of
 	 * filenameToTitle()): keep the title verbatim when it carries its own
 	 * content model, otherwise append the ".wikitext" marker.
-	 *
-	 * @param string $title
-	 * @return string
 	 */
-	public static function titleToFilename($title) {
+	public static function titleToFilename(string $title): string {
 		if (self::titleHasOwnContentModel($title)) {
 			return $title;
 		}
@@ -78,11 +70,8 @@ class SourceFile {
 	 * given title text — i.e. the title (via its extension or namespace) already
 	 * determines the content, so no ".wikitext" marker is needed. Driven by the
 	 * live content-model registry, so it tracks whatever extensions are loaded.
-	 *
-	 * @param string $titleText
-	 * @return bool
 	 */
-	private static function titleHasOwnContentModel($titleText) {
+	private static function titleHasOwnContentModel(string $titleText): bool {
 		$services = MediaWikiServices::getInstance();
 		$title = $services->getTitleFactory()->newFromText($titleText);
 		if (!$title) {

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -64,7 +64,7 @@ class Build extends Maintenance {
 	 * never-collected img-* files. The directory itself is kept (it may be a
 	 * mount point); only its contents are removed.
 	 */
-	private function clearOutputDirectory() {
+	private function clearOutputDirectory(): void {
 		$dir = rtrim($GLOBALS['wgWikvenHtmlDirectory'], '/');
 		if ($dir === '' || !is_dir($dir)) {
 			return;
@@ -85,11 +85,9 @@ class Build extends Maintenance {
 	/**
 	 * Run one build step as a child maintenance script.
 	 *
-	 * @param string $class
-	 * @param string $file
 	 * @param array $options Options to set on the child before it runs.
 	 */
-	private function step($class, $file, array $options = []) {
+	private function step(string $class, string $file, array $options = []): void {
 		$child = $this->createChild($class, $file);
 		foreach ($options as $name => $value) {
 			$child->setOption($name, $value);
@@ -101,10 +99,8 @@ class Build extends Maintenance {
 	 * Upload the image files in the source directory into the File: namespace,
 	 * so pages that embed them render with local thumbnails. Runs core's
 	 * importImages.php over the source directory; non-image files are ignored.
-	 *
-	 * @param string $file
 	 */
-	private function importImages($file) {
+	private function importImages(string $file): void {
 		$child = $this->createChild(ImportImages::class, $file);
 		$child->setArg(0, rtrim($GLOBALS['wgWikvenSourceDirectory'], '/'));
 		$child->setOption('extensions', implode(',', $GLOBALS['wgFileExtensions']));
@@ -117,7 +113,7 @@ class Build extends Maintenance {
 	 * "index" by default). The article itself is imported afterwards; see
 	 * assertMainPageExists().
 	 */
-	private function setMainPage() {
+	private function setMainPage(): void {
 		$title = Title::newFromText('MediaWiki:Mainpage');
 		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
 		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
@@ -133,7 +129,7 @@ class Build extends Maintenance {
 	 * the main page points at a non-existent article, so the static host serves
 	 * no page at the site root while the build otherwise reports success.
 	 */
-	private function assertMainPageExists() {
+	private function assertMainPageExists(): void {
 		$name = $GLOBALS['wgWikvenMainPage'];
 		$title = Title::newFromText($name);
 		if (!$title || !$title->exists()) {

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -97,10 +97,8 @@ class BuildScripts extends Maintenance {
 	/**
 	 * Register every gadget's ResourceLoader module on the given loader, mirroring
 	 * the Gadgets extension's own registration. No-op without the extension.
-	 *
-	 * @param ResourceLoader $rl
 	 */
-	private function registerGadgetModules(ResourceLoader $rl) {
+	private function registerGadgetModules(ResourceLoader $rl): void {
 		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
 		if (!class_exists($repoClass)) {
 			return;
@@ -122,7 +120,7 @@ class BuildScripts extends Maintenance {
 	 *   they can be bundled like the page's own modules), or an empty array when
 	 *   the Gadgets extension is not loaded.
 	 */
-	private function defaultGadgetModules() {
+	private function defaultGadgetModules(): array {
 		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
 		if (!class_exists($repoClass)) {
 			return [];
@@ -140,10 +138,9 @@ class BuildScripts extends Maintenance {
 	}
 
 	/**
-	 * @param string $htmlDir
 	 * @return string[] The union of the RLPAGEMODULES lists across all pages.
 	 */
-	private function collectPageModules($htmlDir) {
+	private function collectPageModules(string $htmlDir): array {
 		$modules = [];
 		foreach (glob("$htmlDir/*.html") as $file) {
 			$html = file_get_contents($file);
@@ -160,13 +157,10 @@ class BuildScripts extends Maintenance {
 	}
 
 	/**
-	 * @param ResourceLoader $rl
 	 * @param string[] $seeds
-	 * @param string $lang
-	 * @param string $skin
 	 * @return string[] The full dependency closure, including the base modules.
 	 */
-	private function resolveClosure(ResourceLoader $rl, array $seeds, $lang, $skin) {
+	private function resolveClosure(ResourceLoader $rl, array $seeds, string $lang, string $skin): array {
 		$query = ResourceLoader::makeLoaderQuery([], $lang, $skin, null, null, Context::DEBUG_OFF, null);
 		$context = new Context($rl, new FauxRequest($query));
 
@@ -201,15 +195,16 @@ class BuildScripts extends Maintenance {
 	}
 
 	/**
-	 * @param ResourceLoader $rl
 	 * @param string[] $modules
-	 * @param string $lang
-	 * @param string $skin
-	 * @param string|null $only
-	 * @param array $extra
-	 * @return string
 	 */
-	private function dump(ResourceLoader $rl, array $modules, $lang, $skin, $only, array $extra) {
+	private function dump(
+		ResourceLoader $rl,
+		array $modules,
+		string $lang,
+		string $skin,
+		?string $only,
+		array $extra
+	): string {
 		$query = ResourceLoader::makeLoaderQuery(
 			$modules,
 			$lang,

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -117,11 +117,8 @@ class FetchExtensions extends Maintenance {
 	/**
 	 * Read and merge default.yaml + the site's .wikven.yaml/.json, exactly as
 	 * WikvenSettings.php does, so the fetched set matches what will be loaded.
-	 *
-	 * @param string $IP
-	 * @return array
 	 */
-	private function loadConfig($IP) {
+	private function loadConfig(string $IP): array {
 		$yaml = new YamlFormat();
 		$config = $yaml->decode(file_get_contents("$IP/extensions/Wikven/default.yaml"));
 
@@ -145,10 +142,9 @@ class FetchExtensions extends Maintenance {
 	}
 
 	/**
-	 * @param array $list
 	 * @return array<string,true> Set of the string names in $list.
 	 */
-	private function nameSet(array $list) {
+	private function nameSet(array $list): array {
 		$set = [];
 		foreach ($list as $entry) {
 			if (is_string($entry)) {
@@ -159,12 +155,11 @@ class FetchExtensions extends Maintenance {
 	}
 
 	/**
-	 * @param string $name
 	 * @param array<string,true> $extensionNames
 	 * @param array<string,true> $skinNames
 	 * @return array{0:string,1:string} [base directory, kind]
 	 */
-	private function target($name, array $extensionNames, array $skinNames) {
+	private function target(string $name, array $extensionNames, array $skinNames): array {
 		$IP = $GLOBALS['IP'];
 		if (isset($extensionNames[$name])) {
 			return ["$IP/extensions", 'extension'];
@@ -181,7 +176,7 @@ class FetchExtensions extends Maintenance {
 	 * @param string $package "vendor/name" or "vendor/name:constraint"
 	 * @return array{0:string,1:string} [package name, version constraint]
 	 */
-	private function splitPackage($package) {
+	private function splitPackage(string $package): array {
 		$pos = strpos($package, ':');
 		if ($pos === false) {
 			return [$package, '*'];
@@ -191,13 +186,8 @@ class FetchExtensions extends Maintenance {
 
 	/**
 	 * The lowercased, validated `sha256:` of a tarball spec, or null if absent.
-	 *
-	 * @param array $spec
-	 * @param string $name
-	 * @param string $kind
-	 * @return ?string
 	 */
-	private function validatedSha256(array $spec, $name, $kind) {
+	private function validatedSha256(array $spec, string $name, string $kind): ?string {
 		if (!isset($spec['sha256'])) {
 			return null;
 		}
@@ -211,13 +201,8 @@ class FetchExtensions extends Maintenance {
 	/**
 	 * The validated `commit:` SHA of a repository spec, or null if absent. Errors
 	 * if it is combined with `reference:`, since the two pin differently.
-	 *
-	 * @param array $spec
-	 * @param string $name
-	 * @param string $kind
-	 * @return ?string
 	 */
-	private function validatedCommit(array $spec, $name, $kind) {
+	private function validatedCommit(array $spec, string $name, string $kind): ?string {
 		if (empty($spec['commit'])) {
 			return null;
 		}
@@ -231,7 +216,7 @@ class FetchExtensions extends Maintenance {
 		return $commit;
 	}
 
-	private function fetchTarball($url, $dest, $name, $kind, $sha256 = null) {
+	private function fetchTarball(string $url, string $dest, string $name, string $kind, ?string $sha256 = null): void {
 		$this->output("Wikven: downloading $kind '$name' from $url\n");
 		$tmp = tempnam(sys_get_temp_dir(), 'wikven');
 		$this->run(['curl', '-sSL', '-f', '-o', $tmp, '--', $url], "download $kind '$name'");
@@ -252,7 +237,7 @@ class FetchExtensions extends Maintenance {
 		unlink($tmp);
 	}
 
-	private function fetchGit(array $spec, $dest, $name, $kind) {
+	private function fetchGit(array $spec, string $dest, string $name, string $kind): void {
 		$repo = (string)$spec['repository'];
 		$commit = $this->validatedCommit($spec, $name, $kind);
 
@@ -290,10 +275,9 @@ class FetchExtensions extends Maintenance {
 	}
 
 	/**
-	 * @param string $IP
 	 * @param array<string,string> $packages package name => constraint
 	 */
-	private function installPackages($IP, array $packages) {
+	private function installPackages(string $IP, array $packages): void {
 		// Core's composer.json merges composer.local.json via composer-merge-plugin,
 		// so registering the requirement there and running composer update at the
 		// root pulls each package (and its dependencies) into place.
@@ -319,9 +303,8 @@ class FetchExtensions extends Maintenance {
 	 * silently produce a wiki missing the feature.
 	 *
 	 * @param string[] $cmd
-	 * @param string $what
 	 */
-	private function run(array $cmd, $what) {
+	private function run(array $cmd, string $what): void {
 		$shell = implode(' ', array_map('escapeshellarg', $cmd));
 		$ret = 0;
 		passthru($shell, $ret);

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -101,10 +101,9 @@ class ImportWikitext extends Maintenance {
 	 * subdirectories so subpages can be supplied as nested files (e.g. a
 	 * template's "Template:Foo/styles.css" in a "Template:Foo/" folder).
 	 *
-	 * @param string $sourceDirectory
 	 * @return string[] Absolute paths, sorted for a stable import order.
 	 */
-	private function wikitextFiles($sourceDirectory) {
+	private function wikitextFiles(string $sourceDirectory): array {
 		$iterator = new \RecursiveIteratorIterator(
 			new \RecursiveDirectoryIterator($sourceDirectory, \FilesystemIterator::SKIP_DOTS)
 		);
@@ -123,12 +122,8 @@ class ImportWikitext extends Maintenance {
 	/**
 	 * Map a page file to its title: the path relative to the source directory,
 	 * resolved by SourceFile's naming convention.
-	 *
-	 * @param string $name
-	 * @param string $sourceDirectory
-	 * @return string
 	 */
-	private function filenameToTitle($name, $sourceDirectory) {
+	private function filenameToTitle(string $name, string $sourceDirectory): string {
 		$relative = substr($name, strlen($sourceDirectory) + 1);
 		return SourceFile::filenameToTitle($relative);
 	}

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -142,7 +142,7 @@ class RewriteScripts extends Maintenance {
 	 *   they are triggered like the page's own modules), or an empty array when
 	 *   the Gadgets extension is not loaded.
 	 */
-	private function defaultGadgetModules() {
+	private function defaultGadgetModules(): array {
 		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
 		if (!class_exists($repoClass)) {
 			return [];
@@ -162,12 +162,8 @@ class RewriteScripts extends Maintenance {
 	/**
 	 * Remove every balanced <div ...$marker...>...</div> from the HTML, where
 	 * $marker is a substring of the opening tag. Handles nested <div>s.
-	 *
-	 * @param string $html
-	 * @param string $marker
-	 * @return string
 	 */
-	private function removeElements($html, $marker) {
+	private function removeElements(string $html, string $marker): string {
 		while (true) {
 			$start = $this->findOpeningDiv($html, $marker);
 			if ($start === -1) {
@@ -182,11 +178,9 @@ class RewriteScripts extends Maintenance {
 	}
 
 	/**
-	 * @param string $html
-	 * @param string $marker
 	 * @return int Byte offset of the opening <div, or -1.
 	 */
-	private function findOpeningDiv($html, $marker) {
+	private function findOpeningDiv(string $html, string $marker): int {
 		$pos = strpos($html, '<div');
 		while ($pos !== false) {
 			$tagEnd = strpos($html, '>', $pos);
@@ -202,11 +196,10 @@ class RewriteScripts extends Maintenance {
 	}
 
 	/**
-	 * @param string $html
 	 * @param int $start Offset of an opening <div.
 	 * @return int Byte offset just past the matching </div>, or -1.
 	 */
-	private function matchingDivEnd($html, $start) {
+	private function matchingDivEnd(string $html, int $start): int {
 		$depth = 0;
 		$len = strlen($html);
 		$i = $start;

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -93,12 +93,11 @@ class StoreImages extends Maintenance {
 	/**
 	 * Download a single remote image and return its local reference.
 	 *
-	 * @param \MediaWiki\Http\HttpRequestFactory $http
 	 * @param string $ref The reference as written in the HTML (may be protocol-relative).
 	 * @param string $dir Output directory.
 	 * @return string|null Local "./img-*.ext" reference, or null on failure.
 	 */
-	private function store($http, $ref, $dir) {
+	private function store(\MediaWiki\Http\HttpRequestFactory $http, string $ref, string $dir): ?string {
 		$url = str_starts_with($ref, '//') ? "https:$ref" : $ref;
 		$name = 'img-' . substr(md5($ref), 0, 12) . '.' . $this->extension($url);
 		$dest = "$dir/$name";
@@ -136,7 +135,7 @@ class StoreImages extends Maintenance {
 	 * @param string $dir Output directory.
 	 * @return string|null Local "./img-*.ext" reference, or null if the file is missing.
 	 */
-	private function storeLocal($src, $path, $dir) {
+	private function storeLocal(string $src, string $path, string $dir): ?string {
 		if (!is_file($src)) {
 			$this->output("  missing: $path\n");
 			return null;
@@ -150,10 +149,9 @@ class StoreImages extends Maintenance {
 	}
 
 	/**
-	 * @param string $url
 	 * @return string A safe lowercase file extension, defaulting to "img".
 	 */
-	private function extension($url) {
+	private function extension(string $url): string {
 		$ext = strtolower((string)pathinfo((string)parse_url($url, PHP_URL_PATH), PATHINFO_EXTENSION));
 		return preg_match('/^[a-z0-9]+$/', $ext) ? $ext : 'img';
 	}


### PR DESCRIPTION
## Why
Per the wikitech-l thread *"PHPCS in a static types world"*: where PHP's native type declarations express a type losslessly, the doc-comment type that duplicated it is noise. wikven's own methods still used the older style (`@param string $x` + untyped signatures).

## What
- Add **native parameter / return / property types** across the extension's own code: `SourceFile`, `Hooks\Main` (helpers + typed properties), `AssetLocalizer`, and the `maintenance/` scripts.
- **Remove the now-redundant** `@param`/`@return`/`@var` lines, but **keep**:
  - lossy doc types native PHP can't express — `@return string[]`, `@param array<string,true>`, `array{0:string,1:string}`;
  - any `@param`/`@return` carrying a description.
- **Left alone** (would fight the framework): hook entry points whose signatures are fixed by the MediaWiki hook interfaces (`Adder`, `Hider`, `Main`'s `on*` methods), and `Maintenance::execute()`/`__construct()` overrides.

This is a style/clarity change with **no behaviour change**.

## Validation
- `php -l` clean on all 9 files.
- **`mago 1.30`** (now matched to CI locally) reports the tree already formatted.
- **PHPUnit: `OK (18 tests, 18 assertions)`** for `SourceFile` (unit + integration) against a real **MediaWiki REL1_45**, confirming the typed signatures accept the real call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)