### PR TITLE
ci: run mediawiki-codesniffer alongside mago

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -73,7 +73,9 @@ jobs:
           persist-credentials: false
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: "8.1"
+          # The lint tools (codesniffer, grumphp, minus-x) require PHP >= 8.2;
+          # this is only the environment phpcs runs in, not wikven's target.
+          php-version: "8.3"
           tools: composer
       - run: composer install --no-interaction --no-progress
       - run: composer phpcs

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -61,3 +61,19 @@ jobs:
         with:
           persist-credentials: false
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
+
+  # MediaWiki coding-standard checks that mago (the formatter) does not cover:
+  # documentation, naming, forbidden patterns, and other semantic rules. The
+  # whitespace sniffs mago owns are excluded in .phpcs.xml.
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: "8.1"
+          tools: composer
+      - run: composer install --no-interaction --no-progress
+      - run: composer phpcs

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,7 +1,28 @@
 <?xml version="1.0" ?>
 <ruleset>
-	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki" />
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<!--
+			Formatting is owned by mago. mago cannot emit MediaWiki's
+			inner-parenthesis spacing (func( $x )), and keeps a class brace on the
+			declaration line even when an implements list wraps, so leave all
+			whitespace and brace placement to mago and skip the sniffs that fight it.
+		-->
+		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis" />
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeClassBrace" />
+		<!--
+			wikven is a build tool: it shells out to git/composer/curl and to its
+			own maintenance steps (passthru, with escapeshellarg used to do so
+			safely), and uses @ for best-effort filesystem operations whose failure
+			is intentionally ignored.
+		-->
+		<exclude name="MediaWiki.Usage.ForbiddenFunctions.passthru" />
+		<exclude name="MediaWiki.Usage.ForbiddenFunctions.escapeshellarg" />
+		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
+	</rule>
 	<file>.</file>
+	<exclude-pattern>vendor/*</exclude-pattern>
+	<exclude-pattern>node_modules/*</exclude-pattern>
 	<arg name="extensions" value="php" />
 	<arg name="encoding" value="UTF-8" />
 </ruleset>

--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -119,40 +119,9 @@ if (file_exists("$wikvenSrc/.wikven.yaml")) {
 $wikvenManifest = json_decode(file_get_contents("$IP/extensions/Wikven/extension.json"), true);
 $wikvenKnownConfig = array_keys($wikvenManifest['config'] ?? []);
 
-/**
- * Warn about site-file mistakes the settings system would otherwise drop
- * silently: an unknown top-level key, a wrong-typed config/extensions/skins, or
- * a misspelled Wikven variable. Validation only; it does not alter the data.
- *
- * @param mixed $data Decoded .wikven.yaml/.json contents.
- * @param string $name File name, for the messages.
- * @param string[] $knownConfig Canonical Wikven config variable names.
- */
-function wikvenValidateSiteFile($data, $name, array $knownConfig) {
-	if (!is_array($data)) {
-		error_log("Wikven: $name is not a map; ignoring it.");
-		return;
-	}
-	foreach (array_keys($data) as $key) {
-		if (!in_array($key, ['config', 'extensions', 'skins'], true)) {
-			error_log("Wikven: $name has an unknown top-level key '$key' (expected config/extensions/skins).");
-		}
-	}
-	foreach (['extensions', 'skins'] as $listKey) {
-		if (isset($data[$listKey]) && !is_array($data[$listKey])) {
-			error_log("Wikven: $name '$listKey' must be a list.");
-		}
-	}
-	if (isset($data['config']) && !is_array($data['config'])) {
-		error_log("Wikven: $name 'config' must be a map.");
-		return;
-	}
-	foreach (array_keys($data['config'] ?? []) as $cfgKey) {
-		if (str_starts_with($cfgKey, 'Wikven') && !in_array($cfgKey, $knownConfig, true)) {
-			error_log("Wikven: $name sets unknown config '$cfgKey' (not a Wikven variable; typo?).");
-		}
-	}
-}
+// This runs while LocalSettings.php is read, before the extension registry has
+// activated Wikven's autoloader, so load the (dependency-free) helper directly.
+require_once "$IP/extensions/Wikven/includes/SiteConfig.php";
 
 // The defaults, then the site file on top. For each, hand its "config" map to
 // $wgSettings (so keys merge per their declared strategy) and collect its
@@ -166,7 +135,10 @@ if ($wikvenSiteFile !== null) {
 		? new MediaWiki\Settings\Source\Format\JsonFormat()
 		: new MediaWiki\Settings\Source\Format\YamlFormat();
 	$wikvenSiteData = $wikvenSiteFormat->decode(file_get_contents($wikvenSiteFile));
-	wikvenValidateSiteFile($wikvenSiteData, basename($wikvenSiteFile), $wikvenKnownConfig);
+	$wikvenSiteName = basename($wikvenSiteFile);
+	foreach (MediaWiki\Extension\Wikven\SiteConfig::lint($wikvenSiteData, $wikvenKnownConfig) as $wikvenWarning) {
+		error_log("Wikven: $wikvenSiteName $wikvenWarning");
+	}
 }
 
 foreach ([$wikvenYamlData, $wikvenSiteData] as $wikvenData) {

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,18 @@
 	"type": "mediawiki-extension",
 	"scripts": {
 		"test": "minus-x check .",
-		"fix": "minus-x fix ."
+		"fix": "minus-x fix .",
+		"phpcs": "phpcs -sp",
+		"phpcbf": "phpcbf"
 	},
 	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "51.0.0",
 		"mediawiki/minus-x": "2.0.1",
 		"phpro/grumphp": "2.21.0"
 	},
 	"config": {
 		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true,
 			"phpro/grumphp": true
 		}
 	}

--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -20,8 +20,8 @@ use MediaWiki\ResourceLoader\ResourceLoader;
  */
 class AssetLocalizer {
 	/**
-	 * @param string $dir Directory the files live in and where images are dumped.
-	 * @param string[] $files Absolute paths of CSS/JS files to rewrite in place.
+	 * Rewrite the image url()s in the given dumped CSS/JS files (absolute paths)
+	 * to point at image copies dumped into $dir.
 	 */
 	public static function localizeImages(
 		ResourceLoader $rl,
@@ -77,9 +77,9 @@ class AssetLocalizer {
 	}
 
 	/**
-	 * Dump a single ResourceLoader image-endpoint URL to a local file.
+	 * Dump a single ResourceLoader image-endpoint URL ($url, a decoded
+	 * /load.php?...image=... reference) to a local file.
 	 *
-	 * @param string $url Decoded /load.php?...image=... reference.
 	 * @return string|null Relative url() target (./img-*.svg), or null if not an image.
 	 */
 	private static function dumpRlImage(
@@ -127,10 +127,10 @@ class AssetLocalizer {
 	}
 
 	/**
-	 * Copy a direct asset path (e.g. /skins/Vector/.../foo.svg) out of the
-	 * MediaWiki install into the output directory.
+	 * Copy a direct asset path ($path, an absolute web path with a leading slash
+	 * and no query, e.g. /skins/Vector/.../foo.svg) out of the MediaWiki install
+	 * into the output directory.
 	 *
-	 * @param string $path Absolute web path (with leading slash, no query).
 	 * @return string|null Relative url() target, or null if the file is missing.
 	 */
 	private static function copyAsset(string $mwRoot, string $path, string $dir): ?string {

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -3,14 +3,14 @@
 namespace MediaWiki\Extension\Wikven\Hooks;
 
 use MediaWiki\Config\Config;
-use MediaWiki\Request\FauxRequest;
+use MediaWiki\Extension\Wikven\SourceFile;
 use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Request\FauxRequest;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
-use MediaWiki\Output\OutputPage;
 use MediaWiki\Title\Title;
-use MediaWiki\Extension\Wikven\SourceFile;
 
 class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPageAfterGetHeadLinksArrayHook {
 	private ?Context $rlClientContext = null;

--- a/includes/SiteConfig.php
+++ b/includes/SiteConfig.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven;
+
+/**
+ * Helpers for a site's .wikven.yaml / .wikven.json configuration file.
+ */
+class SiteConfig {
+	/** Top-level keys the settings format recognises. */
+	private const TOP_LEVEL_KEYS = ['config', 'extensions', 'skins'];
+
+	/**
+	 * Lint decoded site-config contents, returning a warning for each mistake the
+	 * settings system would otherwise drop silently: an unknown top-level key, a
+	 * wrong-typed config/extensions/skins, or a misspelled Wikven variable (which
+	 * would set a global nothing reads). Messages are returned rather than logged
+	 * so the check stays pure and unit-testable.
+	 *
+	 * @param mixed $data Decoded .wikven.yaml/.json contents.
+	 * @param string[] $knownConfig Canonical Wikven config variable names, from extension.json.
+	 * @return string[] Warning messages, empty when the file is sound.
+	 */
+	public static function lint($data, array $knownConfig): array {
+		if (!is_array($data)) {
+			return ['the file is not a map; ignoring it.'];
+		}
+		$warnings = [];
+		foreach (array_keys($data) as $key) {
+			if (!in_array($key, self::TOP_LEVEL_KEYS, true)) {
+				$warnings[] = "unknown top-level key '$key' (expected config/extensions/skins).";
+			}
+		}
+		foreach (['extensions', 'skins'] as $listKey) {
+			if (isset($data[$listKey]) && !is_array($data[$listKey])) {
+				$warnings[] = "'$listKey' must be a list.";
+			}
+		}
+		if (isset($data['config']) && !is_array($data['config'])) {
+			$warnings[] = "'config' must be a map.";
+			return $warnings;
+		}
+		foreach (array_keys($data['config'] ?? []) as $cfgKey) {
+			if (str_starts_with($cfgKey, 'Wikven') && !in_array($cfgKey, $knownConfig, true)) {
+				$warnings[] = "unknown config '$cfgKey' (not a Wikven variable; typo?).";
+			}
+		}
+		return $warnings;
+	}
+}

--- a/mago.toml
+++ b/mago.toml
@@ -40,8 +40,8 @@ empty-line-after-opening-tag = false
 # MediaWiki does not align array tables or assignments.
 array-table-style-alignment = false
 
-# Do not reorder or regroup use statements.
-sort-uses = false
+# Sort use statements, matching mediawiki-codesniffer's UnsortedUseStatements.
+sort-uses = true
 separate-use-types = false
 
 # Preserve author line-breaking decisions to keep the diff minimal.

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -2,15 +2,15 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use MediaWiki\CommentStore\CommentStoreComment;
-use MediaWiki\Content\ContentHandler;
 use ImportImages;
 use Maintenance;
+use MediaWiki\CommentStore\CommentStoreComment;
+use MediaWiki\Content\ContentHandler;
 use MediaWiki\Revision\SlotRecord;
-use RebuildFileCache;
-use RunJobs;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
+use RebuildFileCache;
+use RunJobs;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 	? getenv('MW_INSTALL_PATH')
@@ -83,9 +83,8 @@ class Build extends Maintenance {
 	}
 
 	/**
-	 * Run one build step as a child maintenance script.
-	 *
-	 * @param array $options Options to set on the child before it runs.
+	 * Run one build step as a child maintenance script, setting $options on the
+	 * child before it runs.
 	 */
 	private function step(string $class, string $file, array $options = []): void {
 		$child = $this->createChild($class, $file);

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -2,9 +2,9 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use MediaWiki\Request\FauxRequest;
 use Maintenance;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Request\FauxRequest;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
 
@@ -157,7 +157,6 @@ class BuildScripts extends Maintenance {
 	}
 
 	/**
-	 * @param string[] $seeds
 	 * @return string[] The full dependency closure, including the base modules.
 	 */
 	private function resolveClosure(ResourceLoader $rl, array $seeds, string $lang, string $skin): array {
@@ -194,9 +193,6 @@ class BuildScripts extends Maintenance {
 		return array_keys($resolved);
 	}
 
-	/**
-	 * @param string[] $modules
-	 */
 	private function dump(
 		ResourceLoader $rl,
 		array $modules,

--- a/maintenance/buildStyles.php
+++ b/maintenance/buildStyles.php
@@ -2,9 +2,9 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-use MediaWiki\Request\FauxRequest;
 use Maintenance;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Request\FauxRequest;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
 

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -155,8 +155,6 @@ class FetchExtensions extends Maintenance {
 	}
 
 	/**
-	 * @param array<string,true> $extensionNames
-	 * @param array<string,true> $skinNames
 	 * @return array{0:string,1:string} [base directory, kind]
 	 */
 	private function target(string $name, array $extensionNames, array $skinNames): array {
@@ -274,9 +272,6 @@ class FetchExtensions extends Maintenance {
 		}
 	}
 
-	/**
-	 * @param array<string,string> $packages package name => constraint
-	 */
 	private function installPackages(string $IP, array $packages): void {
 		// Core's composer.json merges composer.local.json via composer-merge-plugin,
 		// so registering the requirement there and running composer update at the

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -2,9 +2,9 @@
 
 namespace MediaWiki\Extension\Wikven;
 
+use Maintenance;
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\ContentHandler;
-use Maintenance;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\StubObject\StubGlobalUser;
 use MediaWiki\Title\Title;

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -196,7 +196,8 @@ class RewriteScripts extends Maintenance {
 	}
 
 	/**
-	 * @param int $start Offset of an opening <div.
+	 * Find the end of the <div> opening at byte offset $start.
+	 *
 	 * @return int Byte offset just past the matching </div>, or -1.
 	 */
 	private function matchingDivEnd(string $html, int $start): int {

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -91,10 +91,9 @@ class StoreImages extends Maintenance {
 	}
 
 	/**
-	 * Download a single remote image and return its local reference.
+	 * Download a single remote image ($ref, the reference as written in the HTML,
+	 * possibly protocol-relative) into $dir and return its local reference.
 	 *
-	 * @param string $ref The reference as written in the HTML (may be protocol-relative).
-	 * @param string $dir Output directory.
 	 * @return string|null Local "./img-*.ext" reference, or null on failure.
 	 */
 	private function store(\MediaWiki\Http\HttpRequestFactory $http, string $ref, string $dir): ?string {

--- a/tests/phpunit/unit/SiteConfigTest.php
+++ b/tests/phpunit/unit/SiteConfigTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Unit;
+
+use MediaWiki\Extension\Wikven\SiteConfig;
+use MediaWikiUnitTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\SiteConfig
+ */
+class SiteConfigTest extends MediaWikiUnitTestCase {
+	private const KNOWN = ['WikvenFooterUrl', 'WikvenEditUrl', 'WikvenMainPage'];
+
+	public function testSoundFileHasNoWarnings() {
+		$data = [
+			'config' => ['WikvenEditUrl' => 'x', 'Sitename' => 'S'],
+			'extensions' => ['Foo'],
+			'skins' => ['Vector']
+		];
+		$this->assertSame([], SiteConfig::lint($data, self::KNOWN));
+	}
+
+	public function testNonMapIsRejected() {
+		$this->assertSame(['the file is not a map; ignoring it.'], SiteConfig::lint('oops', self::KNOWN));
+	}
+
+	public function testUnknownTopLevelKeyWarns() {
+		$warnings = SiteConfig::lint(['extension' => ['Foo']], self::KNOWN);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString("unknown top-level key 'extension'", $warnings[0]);
+	}
+
+	public function testWrongTypedListWarns() {
+		$warnings = SiteConfig::lint(['extensions' => 'Foo'], self::KNOWN);
+		$this->assertContains("'extensions' must be a list.", $warnings);
+	}
+
+	public function testMisspelledWikvenVariableWarns() {
+		$warnings = SiteConfig::lint(['config' => ['WikvenFooterURL' => 'x']], self::KNOWN);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString("unknown config 'WikvenFooterURL'", $warnings[0]);
+	}
+
+	public function testNonWikvenConfigKeyIsNotFlagged() {
+		$this->assertSame(
+			[],
+			SiteConfig::lint(['config' => ['Sitename' => 'S', 'Localtimezone' => 'UTC']], self::KNOWN)
+		);
+	}
+}


### PR DESCRIPTION
## Why
`.phpcs.xml` referenced mediawiki-codesniffer, but the dependency was never installed — phpcs never ran. This wires it up to cover the MediaWiki rules **mago (the formatter) cannot**: documentation, naming, forbidden patterns, and other semantics.

## Division of labour (mago vs phpcs)
mago and the codesniffer disagree on some formatting, so the split is explicit in `.phpcs.xml`:

| Conflict | Resolution |
|---|---|
| Inner-parenthesis spacing `func( $x )` | mago can't emit it → **exclude** `SpaceyParenthesis` + `FunctionDeclarationArgumentSpacing` (mago owns whitespace) |
| Class brace on a wrapped `implements` | mago keeps it on the line → **exclude** `SpaceBeforeClassBrace` |
| Use-statement order | **reconcilable** → mago now `sort-uses = true`, satisfying `UnsortedUseStatements` |
| `passthru` / `escapeshellarg` / `@`-silenced ops | wikven is a build tool that shells out + does best-effort fs → **exclude** with a rationale comment |

After this split, **phpcs reports 0 errors / 0 warnings** and **mago reports the tree formatted** — both pass together.

## Bonus: drop the global function
`WikvenSettings.php` defined a global `wikvenValidateSiteFile()` (the thing phpcs's `PrefixedGlobalFunctions` flagged) — not something a settings file should do. Replaced with **`SiteConfig::lint()`**, a pure, **unit-tested** static method in an autoloaded class. It's `require_once`d directly because the extension autoloader isn't active yet while `LocalSettings.php` is read. The partial `@param` blocks left by the native-types refactor (#79) are emptied so `FunctionComment`'s positional check passes.

## Changes
- `.phpcs.xml`: target the source tree (vendor excluded), with the documented sniff exclusions above.
- `composer.json`: add `mediawiki/mediawiki-codesniffer`, allow the codesniffer installer plugin, add `composer phpcs` / `phpcbf`.
- `.github/workflows/lint.yaml`: a `phpcs` job (setup-php + `composer install` + `composer phpcs`).
- `mago.toml`: `sort-uses = true`.
- `includes/SiteConfig.php` (+ `tests/phpunit/unit/SiteConfigTest.php`); `WikvenSettings.php` uses it.
- Empty the partial `@param` blocks in the maintenance/AssetLocalizer methods.

## Validation (local, mago 1.30 == CI)
- `composer phpcs` → clean (0/0), `mago format --check` → formatted.
- **PHPUnit `OK (25 tests, 27 assertions)`** on MediaWiki REL1_45 (SourceFile + the new SiteConfig).
- Boot-tested `WikvenSettings.php` on REL1_45: warnings fire via `SiteConfig::lint`, config merges, graceful skip, no fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)