### PR TITLE
ci: run composer test via quibble

### DIFF
--- a/.github/workflows/quibble.yaml
+++ b/.github/workflows/quibble.yaml
@@ -22,8 +22,6 @@ jobs:
           quibble-docker-image: quibble-bookworm-php83
           phan-docker-image: mediawiki-phan-php83
 
-  # Runs `composer test` through Quibble's composer-test stage, the single home
-  # for the project's composer checks (currently minus-x; more will be added).
   composer-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/quibble.yaml
+++ b/.github/workflows/quibble.yaml
@@ -21,3 +21,18 @@ jobs:
           # require >= 8.2) — the default php81 images cannot.
           quibble-docker-image: quibble-bookworm-php83
           phan-docker-image: mediawiki-phan-php83
+
+  # Runs `composer test` through Quibble's composer-test stage, the single home
+  # for the project's composer checks (currently minus-x; more will be added).
+  composer-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: femiwiki/quibble-action@961ecc624a6bb53f91747a80054c87fe25d85131 # main
+        with:
+          stage: composer-test
+          mediawiki-version: REL1_45
+          # PHP 8.3 image: wikven's dev deps (minus-x etc.) require >= 8.2.
+          quibble-docker-image: quibble-bookworm-php83


### PR DESCRIPTION
## What

Adds a `composer-test` job to the Quibble workflow that runs the project's `composer test` (currently minus-x) through quibble-action's `composer-test` stage.

## Why

Supersedes the separate host minus-x job (#84, closed). `composer test` will grow over time, so giving it one home in Quibble means new checks are picked up automatically, rather than maintaining a separate pipeline for a minor check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)