### PR TITLE
ci: report coverage to Codecov

### DIFF
--- a/.github/workflows/quibble.yaml
+++ b/.github/workflows/quibble.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # Codecov OIDC upload, no stored token
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/quibble.yaml
+++ b/.github/workflows/quibble.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: femiwiki/quibble-action@961ecc624a6bb53f91747a80054c87fe25d85131 # main
+      - uses: femiwiki/quibble-action@614e10a4363fa08ecde20544a540888c6d08b1ef # main
         with:
           stage: phan
           mediawiki-version: REL1_45
@@ -28,9 +28,27 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: femiwiki/quibble-action@961ecc624a6bb53f91747a80054c87fe25d85131 # main
+      - uses: femiwiki/quibble-action@614e10a4363fa08ecde20544a540888c6d08b1ef # main
         with:
           stage: composer-test
           mediawiki-version: REL1_45
           # PHP 8.3 image: wikven's dev deps (minus-x etc.) require >= 8.2.
           quibble-docker-image: quibble-bookworm-php83
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - id: quibble
+        uses: femiwiki/quibble-action@614e10a4363fa08ecde20544a540888c6d08b1ef # main
+        with:
+          stage: coverage
+          # Coverage tooling lives only on MediaWiki master.
+          mediawiki-version: master
+          quibble-docker-image: quibble-bookworm-php83
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ${{ steps.quibble.outputs.coverage }}/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/quibble.yaml
+++ b/.github/workflows/quibble.yaml
@@ -37,6 +37,9 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Codecov OIDC upload, no stored token
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -51,4 +54,4 @@ jobs:
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ${{ steps.quibble.outputs.coverage }}/clover.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 Read more on <https://chaotic-ground.github.io/wikven/>.
 
 [![Lint](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml/badge.svg)](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml)
+[![codecov](https://codecov.io/gh/chaotic-ground/wikven/graph/badge.svg)](https://codecov.io/gh/chaotic-ground/wikven)
 
 [mediawiki]: https://www.mediawiki.org/
 [wikipedia]: https://www.wikipedia.org/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# Quibble reports coverage from inside the container, so rewrite its paths to the
+# repository layout.
+fixes:
+  - "/workspace/src/extensions/Wikven/::"
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## What

Adds a `coverage` job to the Quibble workflow and reports it to Codecov, plus a README badge.

## How

- New `coverage` job runs quibble-action's `coverage` stage on **MediaWiki master** (the coverage tooling, `generatePHPUnitConfig.php`, lives only on master) and uploads `clover.xml` via `codecov/codecov-action`.
- Authenticates with **GitHub OIDC** (`use_oidc: true` + `id-token: write`), so there is **no `CODECOV_TOKEN` secret to store or rotate**.
- `codecov.yml` rewrites the in-container paths (`/workspace/src/extensions/Wikven/...`) to the repo layout, and keeps the project/patch statuses informational for now.
- Bumps the quibble-action pin to a ref that includes the coverage fix (femiwiki/quibble-action#37); applied to phan/composer-test too for a single ref.

## Setup (maintainer)

- The **Codecov GitHub App** must be installed for the org (done). OIDC then authenticates the upload, no secret needed.
- If Codecov shows files as unmatched after the first successful upload, the `fixes:` prefix in `codecov.yml` may need adjusting.

Implements #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)