### PR TITLE
ci: stop workflows running twice per pull request

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -2,6 +2,7 @@ name: Docker image
 
 on:
   push:
+    branches: [main]
     paths-ignore:
       - 'docs/**'
   pull_request:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 permissions: {}
 

--- a/.github/workflows/quibble.yaml
+++ b/.github/workflows/quibble.yaml
@@ -1,6 +1,9 @@
 name: Quibble
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 permissions: {}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 permissions: {}
 


### PR DESCRIPTION
## What

Restricts `lint`, `test`, and `quibble` workflows to `push: branches: [main]` + `pull_request`, instead of `[push, pull_request]`.

## Why

For a PR from a same-repo branch, GitHub fires **both** the `push` (branch) and `pull_request` events, so every job in those three workflows ran **twice** — that is why a PR showed ~28 checks. This runs each job once on a PR (via `pull_request`), while `main` pushes still run for badges and the Codecov baseline.

## Note for the maintainer

If branch protection lists required status checks by name, confirm the names still match (the `pull_request`-triggered runs keep the same job names, so they should).

🤖 Generated with [Claude Code](https://claude.com/claude-code)