### PR TITLE
ci: test phan and phpunit against master and stable

### DIFF
--- a/.github/workflows/quibble.yaml
+++ b/.github/workflows/quibble.yaml
@@ -12,6 +12,10 @@ jobs:
   # mago's analyzer nor a bare phpcs run can provide.
   phan:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mediawiki-version: [REL1_45, master]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -19,7 +23,7 @@ jobs:
       - uses: femiwiki/quibble-action@614e10a4363fa08ecde20544a540888c6d08b1ef # main
         with:
           stage: phan
-          mediawiki-version: REL1_45
+          mediawiki-version: ${{ matrix.mediawiki-version }}
           # PHP 8.3 images, so the container resolves wikven's dev deps (which
           # require >= 8.2) — the default php81 images cannot.
           quibble-docker-image: quibble-bookworm-php83

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,16 +25,20 @@ jobs:
       - run: go vet ./...
         working-directory: caddy
 
-  # Run the extension's PHPUnit tests against a real MediaWiki, matching the
-  # 1.45 base image the build ships on.
+  # Run the extension's PHPUnit tests against a real MediaWiki: the 1.45 base
+  # the build ships on, and master.
   phpunit:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mediawiki-version: [REL1_45, master]
     steps:
       - name: Check out MediaWiki core
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: wikimedia/mediawiki
-          ref: REL1_45
+          ref: ${{ matrix.mediawiki-version }}
           path: mediawiki
           persist-credentials: false
       - name: Check out Wikven into the extension tree

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -5,8 +5,8 @@ namespace MediaWiki\Extension\Wikven;
 use Maintenance;
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\ContentHandler;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Revision\SlotRecord;
-use MediaWiki\StubObject\StubGlobalUser;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
 use WikiRevision;
@@ -31,7 +31,7 @@ class ImportWikitext extends Maintenance {
 		$sourceDirectory = rtrim($wgWikvenSourceDirectory, '/');
 
 		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
-		StubGlobalUser::setUser($user);
+		RequestContext::getMain()->setUser($user);
 
 		$ok = true;
 		foreach ($this->wikitextFiles($sourceDirectory) as $filename) {


### PR DESCRIPTION
## What

Runs the version-sensitive jobs (`phan`, `phpunit`) as a matrix over **REL1_45** and **master**, so dual-version support is exercised and gated on both. `composer-test` (minus-x) is version-agnostic and stays single; coverage already runs on master.

## master incompatibility found and fixed

The matrix immediately caught a real one: `maintenance/importWikitext.php` used `StubGlobalUser::setUser()`, but `StubGlobalUser` was removed from MediaWiki master. Replaced it with `RequestContext::getMain()->setUser()`, which sets the same main-context user on both REL1_45 and master, so master now passes and gates (no `continue-on-error`).

Implements #86. Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)