### PR TITLE
ci: gate nightly builds on user-facing changes

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,31 @@ on:
 permissions: {}
 
 jobs:
+  # Build only when a feat/fix landed since the last nightly; a scheduled run
+  # after only chores/CI is skipped.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: check
+        run: |
+          proceed=false
+          last=$(git tag -l 'nightly-*' | sort -r | head -1)
+          if [ "$GITHUB_EVENT_NAME" = workflow_dispatch ] || [ -z "$last" ]; then
+            proceed=true
+          elif git log "$last..HEAD" --format='%s' | grep -qE '^(feat|fix)(\(.+\))?!?:'; then
+            proceed=true
+          fi
+          echo "proceed=$proceed" >> "$GITHUB_OUTPUT"
+
   prepare:
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the dated pre-release


### PR DESCRIPTION
## What

A scheduled nightly now builds only when a **feat/fix commit landed since the last nightly**; a run after only chores/CI is skipped. `workflow_dispatch` (manual) still always builds.

## Why not "open release PR"

An earlier idea was to gate on release-please having an open release PR, but that breaks when a release is deferred: the release PR can stay open for a week, so every nightly in that window would still build. Comparing against the last `nightly-*` tag instead means a deferred release no longer forces daily builds — only a new feat/fix triggers one.

## How

A `gate` job checks out full history, finds the latest `nightly-*` tag, and sets `proceed=true` if `git log <tag>..HEAD` contains a `feat`/`fix` commit (or there is no prior tag, or it is a manual dispatch). `prepare` depends on it, so `binary`/`publish` cascade-skip.

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)