### PR TITLE
ci: enable mago lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,7 +45,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: nhedger/setup-mago@473d3a2bfe0b32a62c8b910059d7f03a16519f2e # v2.0.0
+        with:
+          version: "1.29.0"
       - run: mago format --check
+      - run: mago lint
 
   zizmor:
     runs-on: ubuntu-latest

--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -33,8 +33,8 @@ if ($wikvenWorkEnv !== false && $wikvenWorkEnv !== '') {
 	$wgCacheDirectory = "$wikvenCache/mw";
 	$wgTmpDirectory = "$wikvenCache/tmp";
 	foreach ([$wgUploadDirectory, $wgCacheDirectory, $wgTmpDirectory] as $wikvenDir) {
-		if (!is_dir($wikvenDir)) {
-			@mkdir($wikvenDir, 0777, true);
+		if (!is_dir($wikvenDir) && !mkdir($wikvenDir, 0777, true) && !is_dir($wikvenDir)) {
+			throw new \RuntimeException("Wikven: could not create directory $wikvenDir");
 		}
 	}
 }

--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -113,7 +113,7 @@ class AssetLocalizer {
 		$rl->respond(new Context($rl, new FauxRequest($query)));
 		$bytes = ob_get_clean();
 
-		$isSvg = $bytes !== false && strpos($bytes, '<svg') !== false;
+		$isSvg = $bytes !== false && str_contains($bytes, '<svg');
 		$isPng = $bytes !== false && strncmp($bytes, "\x89PNG\r\n\x1a\n", 8) === 0;
 		if (!$isSvg && !$isPng) {
 			return null;

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -28,7 +28,7 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 
 	/** @inheritDoc */
 	public function onGetLocalURL($title, &$url, $query) {
-		if (MW_ENTRY_POINT != 'cli') {
+		if (MW_ENTRY_POINT !== 'cli') {
 			return;
 		}
 		if ($title->getInterwiki()) {
@@ -96,7 +96,7 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 			if (!$module) {
 				return false;
 			}
-			if (in_array($module->getGroup(), ['site', 'noscript', 'private', 'user'])) {
+			if (in_array($module->getGroup(), ['site', 'noscript', 'private', 'user'], true)) {
 				return false;
 			}
 			return true;
@@ -115,7 +115,7 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 	}
 
 	private function addStyleToList(string $name): void {
-		if (MW_ENTRY_POINT != 'cli') {
+		if (MW_ENTRY_POINT !== 'cli') {
 			return;
 		}
 

--- a/mago.toml
+++ b/mago.toml
@@ -52,3 +52,27 @@ preserve-breaking-parameter-list = true
 preserve-breaking-attribute-list = true
 preserve-breaking-conditional-expression = true
 preserve-breaking-condition-expression = true
+
+# mago is primarily a formatter here. Disable lint rules that conflict with the
+# MediaWiki coding style (already enforced by mediawiki-codesniffer) or are noisy
+# metrics, keeping only correctness-oriented rules.
+[linter.rules]
+braced-string-interpolation = { enabled = false }
+literal-named-argument = { enabled = false }
+no-global = { enabled = false }
+no-isset = { enabled = false }
+no-empty = { enabled = false }
+strict-types = { enabled = false }
+no-else-clause = { enabled = false }
+prefer-early-continue = { enabled = false }
+file-name = { enabled = false }
+explicit-octal = { enabled = false }
+no-shorthand-ternary = { enabled = false }
+cyclomatic-complexity = { enabled = false }
+kan-defect = { enabled = false }
+halstead = { enabled = false }
+too-many-methods = { enabled = false }
+excessive-parameter-list = { enabled = false }
+prefer-arrow-function = { enabled = false }
+no-boolean-flag-parameter = { enabled = false }
+tagged-todo = { enabled = false }

--- a/mago.toml
+++ b/mago.toml
@@ -53,8 +53,7 @@ preserve-breaking-attribute-list = true
 preserve-breaking-conditional-expression = true
 preserve-breaking-condition-expression = true
 
-# mago is primarily a formatter here. Disable lint rules that conflict with the
-# MediaWiki coding style (already enforced by mediawiki-codesniffer) or are noisy
+# Disable lint rules that conflict with the MediaWiki coding style or are noisy
 # metrics, keeping only correctness-oriented rules.
 [linter.rules]
 braced-string-interpolation = { enabled = false }

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -188,7 +188,7 @@ class RewriteScripts extends Maintenance {
 			if ($tagEnd === false) {
 				return -1;
 			}
-			if (strpos(substr($html, $pos, $tagEnd - $pos), $marker) !== false) {
+			if (str_contains(substr($html, $pos, $tagEnd - $pos), $marker)) {
 				return $pos;
 			}
 			$pos = strpos($html, '<div', $tagEnd + 1);


### PR DESCRIPTION
## What

Turns on `mago lint` in CI (it was only used as a formatter before).

## How

- **mago.toml**: disable the ~19 lint rules that conflict with MediaWiki style (already enforced by mediawiki-codesniffer) or are noisy metrics — `braced-string-interpolation`, `literal-named-argument`, `no-global`, `no-isset`, `strict-types`, etc. — keeping correctness-oriented rules (`identity-comparison`, `str-contains`, `strict-behavior`, `no-error-control-operator`).
- **Code**: fix the existing violations of the kept rules — `strpos(...) !== false` → `str_contains`, `!=` → `!==`, the `in_array` strict flag, and replacing `@mkdir` with explicit failure handling.
- **CI**: run `mago lint` in the existing `mago` job, pinned to mago `1.29.0` for reproducible rule behavior.

mago lint is now clean (0 findings), so it gates future code without the style noise.

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)