### PR TITLE
feat: bundle the native search closure so SifterSearch search works offline

### DIFF
--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -3,7 +3,9 @@
 namespace MediaWiki\Extension\Wikven;
 
 use Maintenance;
+use MediaWiki\HookContainer\HookRunner;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Request\FauxRequest;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
@@ -68,6 +70,18 @@ class BuildScripts extends Maintenance {
 		// at request time, which the static render does not reproduce, so seed them
 		// so default gadgets are bundled too.
 		$seeds = array_merge($seeds, $this->defaultGadgetModules());
+		// SifterSearch serves search from a static Pagefind bundle, so the native
+		// search module can run offline once it is in the bundle. It is loaded
+		// lazily on search-box focus and so never appears in a page's module queue;
+		// seed the search module mediawiki.page.ready will load (after the
+		// SkinPageReadyConfig hook, which SifterSearch rewrites to its own
+		// Pagefind-backed module) so its closure (codex/vue) is bundled too.
+		if (ExtensionRegistry::getInstance()->isLoaded('SifterSearch')) {
+			$searchModule = $this->resolveSearchModule($rl, $wgLanguageCode, $wgDefaultSkin);
+			if ($searchModule !== null && $rl->isModuleRegistered($searchModule)) {
+				$seeds[] = $searchModule;
+			}
+		}
 		// 2. Expand to the full dependency closure, plus the implicit base modules.
 		$closure = $this->resolveClosure($rl, $seeds, $wgLanguageCode, $wgDefaultSkin);
 
@@ -156,6 +170,22 @@ class BuildScripts extends Maintenance {
 			}
 		}
 		return array_keys($modules);
+	}
+
+	/**
+	 * @return string|null The search module mediawiki.page.ready lazy-loads on
+	 *   focus, after the SkinPageReadyConfig hook (which the active skin and
+	 *   SifterSearch use to point it at their own module), or null if search is off.
+	 */
+	private function resolveSearchModule(ResourceLoader $rl, string $lang, string $skin): ?string {
+		$query = ResourceLoader::makeLoaderQuery([], $lang, $skin, null, null, Context::DEBUG_OFF, null);
+		$context = new Context($rl, new FauxRequest($query));
+		$config = ['search' => true, 'searchModule' => 'mediawiki.searchSuggest'];
+		( new HookRunner(MediaWikiServices::getInstance()->getHookContainer()) )->onSkinPageReadyConfig(
+			$context,
+			$config
+		);
+		return $config['search'] ?? false ? $config['searchModule'] ?? null : null;
 	}
 
 	/**

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\Wikven;
 
 use Maintenance;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Registration\ExtensionRegistry;
 
 $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 	? getenv('MW_INSTALL_PATH')
@@ -43,6 +44,11 @@ class RewriteScripts extends Maintenance {
 		$hasSiteStyles = is_file("$htmlDir/site.styles.css") && filesize("$htmlDir/site.styles.css") > 0;
 
 		$rl = MediaWikiServices::getInstance()->getResourceLoader();
+
+		// SifterSearch serves search from a static Pagefind bundle and keeps the
+		// native search box working offline (buildScripts bundles its module
+		// closure), so the search box is left in place when it is enabled.
+		$sifterEnabled = ExtensionRegistry::getInstance()->isLoaded('SifterSearch');
 
 		foreach (glob("$htmlDir/*.html") as $file) {
 			$html = file_get_contents($file);
@@ -121,12 +127,15 @@ class RewriteScripts extends Maintenance {
 				$html
 			);
 
-			// Search cannot work on a static host (it needs the API), and the JS
-			// search widget lazily fetches codex/vue from load.php. Drop the search
-			// boxes, and the skin-vector-search-vue body class that makes the sticky
-			// header load the search module, so nothing mounts and nothing is fetched.
-			$html = $this->removeElements($html, 'vector-search-box-vue');
-			$html = str_replace(' skin-vector-search-vue', '', $html);
+			// Without SifterSearch, search cannot work on a static host (it needs the
+			// API) and the JS search widget lazily fetches codex/vue from load.php, so
+			// drop the search boxes and the skin-vector-search-vue body class that
+			// makes the sticky header load the search module, so nothing mounts and
+			// nothing is fetched. With SifterSearch the box is kept (see above).
+			if (!$sifterEnabled) {
+				$html = $this->removeElements($html, 'vector-search-box-vue');
+				$html = str_replace(' skin-vector-search-vue', '', $html);
+			}
 
 			// The appearance menu (dark mode / width) pulls in codex+vue from
 			// load.php for its widgets, which 404s and cannot work statically.


### PR DESCRIPTION
## What

Make the **native** search box work on the static export when SifterSearch is
installed, instead of stripping it. (Consumer half of #97.)

- `buildScripts.php`: seed the search module `mediawiki.page.ready` lazy-loads on
  focus into the static dump. The effective module is resolved through the
  `SkinPageReadyConfig` hook (so it picks up whatever the skin and SifterSearch
  set it to, e.g. `ext.sifter.vector`), and `resolveClosure()` then pulls in its
  whole closure (`mediawiki.skinning.typeaheadSearch`, `mediawiki.codex.typeaheadSearch`,
  `vue`, ...). With the closure pre-`impl()`'d, `mw.loader.using()` resolves it
  offline (no `load.php`).
- `rewriteScripts.php`: keep the search box and the `skin-vector-search-vue` body
  class instead of stripping them, so the Vue/jquery.suggestions UI has DOM to
  mount on.

Both are gated on `ExtensionRegistry::isLoaded('SifterSearch')`, so sites without
SifterSearch are unchanged (box still stripped, no extra modules bundled).

## Why

The native search is lazy-loaded from `load.php`, which 404s on a static host, so
we used to strip it. SifterSearch serves results from a static Pagefind bundle,
so the only missing piece is making the search module resolve offline, which is
exactly what bundling its closure does. No `load.php` emulation is needed.

## Verification (end-to-end, local Docker build)

With SifterSearch enabled and this change:
- modules bundle grew 28 -> 33 modules (the search closure); no `load.php?only=styles` in the bundle.
- the Vector search box and `skin-vector-search-vue` class are preserved.
- in a browser: focusing the box mounts the native Codex typeahead (resolved from
  the bundle, state `ready`), typing returns Pagefind results with correct
  titles/excerpts/static URLs, and **zero** `load.php`/`rest.php`/`api.php`
  requests fire (only static assets + `/pagefind/`). No console errors/warnings.

## Depends on

- SifterSearch's Vector Pagefind client (chaotic-ground/SifterSearch#8, merged as
  ext.sifter.vector). The docs site will pick this up via a SifterSearch release;
  the docs `.wikven.yaml` integration is tracked separately.

Refs #97
