### PR TITLE
fix: show the search box when SifterSearch provides static search

### DIFF
--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Wikven\Hooks;
 
 use MediaWiki\Html\Html;
+use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Skin\Skin;
 
 class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\SkinAddFooterLinksHook {
@@ -10,6 +11,13 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 	public function onBeforePageDisplay($out, $skin): void {
 		$out->addModuleStyles('ext.Wikven.styles');
 		$out->addModules('ext.Wikven.pinnableState');
+
+		// The header search box has no working backend on a static site, so hide
+		// it, unless SifterSearch is installed to serve search from a static
+		// Pagefind bundle.
+		if (!ExtensionRegistry::getInstance()->isLoaded('SifterSearch')) {
+			$out->addInlineStyle('#p-search { display: none; }');
+		}
 	}
 
 	/** @inheritDoc */

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -4,7 +4,6 @@
 #footer-places-about,
 #footer-places-disclaimer,
 #footer-places-disclaimers,
-#p-search,
 #footer-info-credits,
 #footer-info-lastmod,
 // There is not a option to disable some or all talk namespaces (T35298)


### PR DESCRIPTION
## Problem

After enabling SifterSearch (#96, #98), the native search box was still not
visible on the docs site. The header search box `#p-search` was being hidden by
CSS (`resources/ext.Wikven.styles.less`), a leftover from when search could not
work on a static host. So even though the module closure was bundled and the box
kept in the HTML, it stayed `display: none`.

## Fix

- Drop `#p-search` from the always-on `ext.Wikven.styles.less` hide list.
- In `Adder::onBeforePageDisplay`, hide `#p-search` via an inline style only when
  SifterSearch is **not** installed, mirroring how the module bundling and box
  stripping are already gated on `ExtensionRegistry::isLoaded('SifterSearch')`.

So: with SifterSearch the box is shown and serves Pagefind results; without it
the box stays hidden (and is also stripped from the HTML for Vector).

## Verification (local Docker build, real v0.2.0 tarball)

- Built `ext.Wikven.styles.css` no longer hides `#p-search`; no inline hide is
  emitted (SifterSearch is loaded).
- In a browser at desktop width, `#p-search` computes to `display: block`
  (1140x32, visible) with no manual override, and typing returns Pagefind
  results in the native Codex dropdown (7 results, zero backend calls).
