### PR TITLE
docs: document and recommend SifterSearch for client-side search

### DIFF
--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -57,7 +57,7 @@ The <code>run</code> script:
 ; <code>buildScripts</code>
 : Dumps the JavaScript the pages need into two files: <code>startup-static.js</code> (the loader manifest, with its network auto-load removed) and <code>modules-static.js</code> (the full dependency closure, so every module self-executes). It seeds the <code>site</code> module (<code>MediaWiki:Common.js</code> and the skin's JS) and any default [[JavaScript|gadgets]], which a live wiki pulls in implicitly.
 ; <code>rewriteScripts</code>
-: Rewrites the cached HTML to load the local bundle instead of <code>load.php</code>: it swaps the async startup tag for the static files plus an explicit <code>mw.loader.load()</code>, links the site styles last so they win the cascade, and removes the search box and appearance menu, which need a live API.
+: Rewrites the cached HTML to load the local bundle instead of <code>load.php</code>: it swaps the async startup tag for the static files plus an explicit <code>mw.loader.load()</code>, links the site styles last so they win the cascade, and removes the appearance menu (and the search box, unless [[Search|SifterSearch]] is providing a static index), which need a live API.
 ; <code>storeImages</code>
 : Copies every referenced image (from Wikimedia Commons via InstantCommons, or from local uploads) to a content-hashed local file and rewrites the URLs, so nothing is fetched over the network at view time.
 ; <code>rename</code>

--- a/docs/JavaScript.wikitext
+++ b/docs/JavaScript.wikitext
@@ -21,5 +21,5 @@ List your gadgets in <code>MediaWiki:Gadgets-definition.wikitext</code>, and put
 
 Only gadgets marked <code>default</code> are loaded: a static site has no logged-in readers to turn other gadgets on. A gadget's own CSS (in the same module) is included, but standalone styles-only gadgets are not yet covered.
 
-{{prevnext|Skins|wikven.yaml}}
+{{prevnext|Skins|Search}}
 {{DISPLAYTITLE:JavaScript}}

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -7,6 +7,7 @@
 ** Images|Images
 ** Skins|Skins
 ** JavaScript|JavaScript
+** Search|Search
 * References
 ** wikven.yaml|.wikven.yaml
 ** Development|Development

--- a/docs/Search.wikitext
+++ b/docs/Search.wikitext
@@ -1,0 +1,31 @@
+Static sites have no server to answer queries, so MediaWiki's built-in search does not work in the export. For search on a {{wikven}} site, the recommended option is [https://github.com/chaotic-ground/SifterSearch SifterSearch], which builds a static search index at build time and serves results entirely in the browser. This documentation site uses it.
+
+== How it works ==
+
+SifterSearch indexes the rendered pages with [https://pagefind.app/ Pagefind] and writes a static index bundle into the build output. On each page it feeds those results into the skin's own search box (Vector 2022's typeahead, or the classic suggestions box on other skins), so search runs with no API, database, or <code>load.php</code> behind it.
+
+== Enabling it ==
+
+SifterSearch is not bundled, so fetch it in [[wikven.yaml|.wikven.yaml]] and tell it where to write and serve the index:
+
+<syntaxhighlight lang="yaml">
+extensions:
+  - SifterSearch
+config:
+  # Filesystem path of the index bundle, inside the build output directory.
+  SifterSearchOutputDir: /workspace/dist/pagefind
+  # URL path the bundle is served from.
+  SifterSearchBundlePath: /pagefind/
+  WikvenRepositories:
+    # The release tarball bundles the Pagefind binary, which a git clone omits.
+    # Pick the tarball for the platform the build runs on.
+    SifterSearch:
+      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.2.0/SifterSearch-linux-x64.tar.gz
+</syntaxhighlight>
+
+<code>SifterSearchOutputDir</code> is a filesystem path inside the build output (the image writes the site to <code>/workspace/dist</code>); <code>SifterSearchBundlePath</code> is the URL it is served from. If your site lives in a subdirectory, include it: this site deploys under <code>/wikven</code> on GitHub Pages, so it uses <code>/wikven/pagefind/</code>.
+
+{{note|For a reproducible build, pin a released version and add its <code>sha256</code>, as with any tarball source. See [[wikven.yaml#WikvenRepositories|.wikven.yaml]] for the fetch options.}}
+
+{{prevnext|JavaScript|wikven.yaml}}
+{{DISPLAYTITLE:Search}}

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -16,12 +16,12 @@ With {{wikven}}, you can use the following features of MediaWiki.
 * [[JavaScript]] (MediaWiki:Common.js and gadgets)
 * {{ml|Bundled extensions and skins}}
 * Third-party extensions and skins (see [[wikven.yaml|.wikven.yaml]])
+* [[Search]] (client-side, via the SifterSearch extension)
 
 == Unsupported features ==
 
 These need a live wiki, so they are not part of the static export:
 
-* Search
 * All special pages
 * All editors ({{ml|Extension:WikiEditor|WikiEditor}}, <!--
 -->{{ml|Extension:VisualEditor|VisualEditor}} and {{ml|Extension:CodeEditor|CodeEditor}})

--- a/docs/wikven.yaml.wikitext
+++ b/docs/wikven.yaml.wikitext
@@ -95,4 +95,4 @@ docker run --rm --entrypoint cat ghcr.io/chaotic-ground/wikven extensions/Wikven
 
 It is also in the [https://github.com/chaotic-ground/wikven/blob/main/default.yaml repository].
 
-{{prevnext|JavaScript|Development}}
+{{prevnext|Search|Development}}


### PR DESCRIPTION
## What

Document client-side search and recommend SifterSearch.

- `index`: drop **Search** from "Unsupported features" and list it under
  "Supported features" (client-side, via SifterSearch).
- New **Search** page: explains how SifterSearch builds a static Pagefind index
  and feeds the native search box, with the `.wikven.yaml` config to enable it.
  Linked from the sidebar and the prev/next chain (JavaScript -> Search ->
  .wikven.yaml).
- `Development`: correct the `rewriteScripts` description, which now keeps the
  search box when SifterSearch provides a static index.

## Follow-up (not in this PR)

The Vector typeahead's "Search for pages containing X" footer still links to
`/index.php?title=Special:Search...`, which 404s on a static host. Handling that
is tracked separately (options: hide it, or point it at a static Pagefind
results page).
