### PR TITLE
fix: hide the dead full-text search footer on the docs site

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -16,6 +16,8 @@ config:
   # served under /wikven on GitHub Pages.
   SifterSearchOutputDir: /workspace/dist/pagefind
   SifterSearchBundlePath: /wikven/pagefind/
+  # No full-text search page on a static export, so hide that affordance.
+  SifterSearchFullText: false
   WikvenRepositories:
     # TabberNeue is not bundled in the image; clone it from Git to show off
     # third-party fetching. (TemplateStyles, which the templates use, is bundled
@@ -25,5 +27,5 @@ config:
       reference: v4.0.0
     # The release tarball bundles the Pagefind binary, which a git clone omits.
     SifterSearch:
-      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.2.0/SifterSearch-linux-x64.tar.gz
-      sha256: d7f8896478195be8597a5426ed724bb011844eeb83abf1afd098b2a7bf5a83b3
+      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.3.0/SifterSearch-linux-x64.tar.gz
+      sha256: e8dea1e3b1c37cc2f48f5bbe41df255b25a517f61982021e31ade4bcaf7183b2


### PR DESCRIPTION
## What

Hide the Vector typeahead's "search for pages containing X" footer on the docs
site. It links to `Special:Search`, which 404s on the static export.

- Bump the SifterSearch pin to **v0.3.0**, which adds `$wgSifterSearchFullText`.
- Set `SifterSearchFullText: false` so the full-text affordance is not shown.

## Verification

Local build with the v0.3.0 tarball: sha256 verified, build succeeds,
`wgSifterSearchFullText":false` in the output, and (verified separately on a
static build) the typeahead still returns Pagefind results while the
"search for pages containing" footer is gone.

Remaining follow-ups (Enter/Search-button submit, a real results page) are
tracked in chaotic-ground/SifterSearch#12.



BEGIN_COMMIT_OVERRIDE
docs: hide the dead full-text search footer on the docs site
END_COMMIT_OVERRIDE
