### PR TITLE
fix: send the search submit to the top result on the docs site

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -27,5 +27,5 @@ config:
       reference: v4.0.0
     # The release tarball bundles the Pagefind binary, which a git clone omits.
     SifterSearch:
-      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.3.0/SifterSearch-linux-x64.tar.gz
-      sha256: e8dea1e3b1c37cc2f48f5bbe41df255b25a517f61982021e31ade4bcaf7183b2
+      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.4.0/SifterSearch-linux-x64.tar.gz
+      sha256: c90d1c25093840b6e36426f87df967a30b042668549de56e17540246e2b962a6


### PR DESCRIPTION
Bump SifterSearch to v0.4.0. With `SifterSearchFullText: false`, an Enter / Search-button submit now goes to the top Pagefind result instead of the absent `Special:Search`. Verified locally: submitting "binary" navigates to /wikven/Binary.html; sha256 verified. Completes the full-text-affordance items in chaotic-ground/SifterSearch#12 (the optional static results page remains).


BEGIN_COMMIT_OVERRIDE
docs: send the search submit to the top result on the docs site
END_COMMIT_OVERRIDE
