### PR TITLE
feat: add a full search results page to the docs site

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -18,6 +18,7 @@ config:
   SifterSearchBundlePath: /wikven/pagefind/
   # No full-text search page on a static export, so hide that affordance.
   SifterSearchFullText: false
+  SifterSearchResultsPage: "Search results"
   WikvenRepositories:
     # TabberNeue is not bundled in the image; clone it from Git to show off
     # third-party fetching. (TemplateStyles, which the templates use, is bundled
@@ -27,5 +28,5 @@ config:
       reference: v4.0.0
     # The release tarball bundles the Pagefind binary, which a git clone omits.
     SifterSearch:
-      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.4.0/SifterSearch-linux-x64.tar.gz
-      sha256: c90d1c25093840b6e36426f87df967a30b042668549de56e17540246e2b962a6
+      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.5.0/SifterSearch-linux-x64.tar.gz
+      sha256: 46047e5215d1941d3accc3aaea30bb728e01c8816f9632c9d98fd570cc0647a6

--- a/docs/Search results.wikitext
+++ b/docs/Search results.wikitext
@@ -1,0 +1,2 @@
+__NOTOC__
+{{DISPLAYTITLE:Search results}}

--- a/docs/Search.wikitext
+++ b/docs/Search.wikitext
@@ -16,6 +16,10 @@ config:
   SifterSearchOutputDir: /workspace/dist/pagefind
   # URL path the bundle is served from.
   SifterSearchBundlePath: /pagefind/
+  # A static export has no Special:Search, so do not offer it.
+  SifterSearchFullText: false
+  # A content page that shows the full results (see below).
+  SifterSearchResultsPage: "Search results"
   WikvenRepositories:
     # The release tarball bundles the Pagefind binary, which a git clone omits.
     # Pick the tarball for the platform the build runs on.
@@ -26,6 +30,15 @@ config:
 <code>SifterSearchOutputDir</code> is a filesystem path inside the build output (the image writes the site to <code>/workspace/dist</code>); <code>SifterSearchBundlePath</code> is the URL it is served from. If your site lives in a subdirectory, include it: this site deploys under <code>/wikven</code> on GitHub Pages, so it uses <code>/wikven/pagefind/</code>.
 
 {{note|For a reproducible build, pin a released version and add its <code>sha256</code>, as with any tarball source. See [[wikven.yaml#WikvenRepositories|.wikven.yaml]] for the fetch options.}}
+
+== Full results page ==
+
+The skin's search box shows the top matches as you type. For a page that lists
+all matches, create an (otherwise empty) content page and name it in
+<code>SifterSearchResultsPage</code>. SifterSearch mounts its full search UI
+there and runs the query from the URL, and the search box's "search for pages
+containing…" action and its Enter key go to that page. This site uses a page
+titled <code>Search results</code>.
 
 {{prevnext|JavaScript|wikven.yaml}}
 {{DISPLAYTITLE:Search}}


### PR DESCRIPTION
Bump SifterSearch to v0.5.0 and set `SifterSearchResultsPage: "Search results"` with a new (empty) "Search results" content page. SifterSearch mounts PagefindUI there and runs the query from `?search=`; the search box's full-text action / Enter now lands on it. Documented on the Search page. Verified locally: sha256 matches, Search_results.html builds with ext.sifter.results bundled and pagefind-ui.{js,css} in the bundle; the page renders results and the footer/submit navigate there with the query.


BEGIN_COMMIT_OVERRIDE
docs: add a full search results page to the docs site
END_COMMIT_OVERRIDE
