### PR TITLE
fix: name the project namespace Wikven instead of clashing with MediaWiki

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -6,6 +6,11 @@
 config:
   Sitename: Wikven
 
+  # Name the project namespace after the site. The installer hardcodes it to the
+  # install-time wiki name ("MediaWiki"), which collides with the MediaWiki
+  # namespace and makes the project namespace fall back to the generic "Project".
+  MetaNamespace: Wikven
+
   # Keep the first letter of page titles as written instead of force-capitalizing
   # it (MediaWiki's default). The entry page is the lowercase "index", which the
   # build writes as index.html, the file a static host (GitHub Pages, and web


### PR DESCRIPTION
The installer hardcodes `$wgMetaNamespace` to the install-time wiki name "MediaWiki", which collides with the MediaWiki namespace; the project namespace then silently falls back to the generic "Project". Set `MetaNamespace: Wikven` in default.yaml (next to `Sitename: Wikven`) so it is named after the site and no longer clashes.

Verified in the build container (install + WikvenSettings): NS_PROJECT becomes "Wikven" (was "Project"), NS_MEDIAWIKI stays "MediaWiki". Docs build unaffected.