### PR TITLE
fix: drop the empty typeahead thumbnail column on the docs site

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -12,6 +12,14 @@ config:
   WikvenHistoryUrl: https://github.com/chaotic-ground/wikven/commits/main/docs/$1
   WikvenLogos:
     icon: logo.svg
+  # Search results have no thumbnails, so drop the empty thumbnail column from
+  # the typeahead.
+  VectorTypeahead:
+    apiUrl: null
+    recommendationApiUrl: null
+    options:
+      showThumbnail: false
+      showDescription: true
   # Pagefind index: written into the build output (/workspace/dist in the image),
   # served under /wikven on GitHub Pages.
   SifterSearchOutputDir: /workspace/dist/pagefind


### PR DESCRIPTION
Pagefind results have no thumbnails, so Vector's typeahead rendered an empty thumbnail column. Set `VectorTypeahead.options.showThumbnail: false` (keeping `showDescription`). Pairs with SifterSearch dropping the results-page image column (now in the nightly). Verified on a local build: the typeahead no longer has the `cdx-typeahead-search--show-thumbnail` class and results render without thumbnails.


BEGIN_COMMIT_OVERRIDE
docs: drop the empty typeahead thumbnail column on the docs site
END_COMMIT_OVERRIDE
