### PR TITLE
fix: make the first listed skin the default skin

### DIFF
--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -168,6 +168,7 @@ $config['skins'] = array_values(array_unique(array_filter($config['skins'], 'is_
 // Skins. Register each named skin and use the first as the default. Only skins
 // bundled in this image can be enabled; an unknown name is skipped with a
 // warning instead of aborting the whole build.
+$wikvenDefaultSkinChosen = false;
 foreach ($config['skins'] ?? [] as $skin) {
 	if (!is_string($skin)) {
 		continue;
@@ -177,15 +178,16 @@ foreach ($config['skins'] ?? [] as $skin) {
 		continue;
 	}
 	wfLoadSkin($skin);
-	if (!isset($wgDefaultSkin)) {
-		// A skin's default-skin name (e.g. 'minerva') can differ from its
-		// directory name (e.g. 'MinervaNeue'), so read the canonical name from
-		// the skin's own skin.json instead of guessing it.
+	// Set the default unconditionally: the installer already wrote $wgDefaultSkin,
+	// so a !isset guard never fires. A skin's canonical name (e.g. 'minerva') can
+	// differ from its directory ('MinervaNeue'), so read it from its skin.json.
+	if (!$wikvenDefaultSkinChosen) {
 		$wgDefaultSkin = strtolower($skin);
 		$skinMeta = json_decode(file_get_contents("$IP/skins/$skin/skin.json"), true);
 		if (isset($skinMeta['ValidSkinNames']) && is_array($skinMeta['ValidSkinNames'])) {
 			$wgDefaultSkin = (string)array_key_first($skinMeta['ValidSkinNames']);
 		}
+		$wikvenDefaultSkinChosen = true;
 	}
 }
 


### PR DESCRIPTION
## What

The installer writes `$wgDefaultSkin` to `LocalSettings.php` for every bundled skin, so the old `if (!isset($wgDefaultSkin))` guard in `WikvenSettings.php` never fired. The first entry in `.wikven.yaml`'s `skins:` list never actually became the active default, so non-Vector skins could not be selected.

This sets the default unconditionally via a one-shot flag, reading each skin's canonical name from its `skin.json` (`ValidSkinNames`), since that can differ from the directory name (e.g. `minerva` vs `MinervaNeue`).

## Why

Foundation for multi-skin support (#107): without this, `skins:` is effectively ignored and the site always renders Vector.

## Test

No behavior change for the dogfood docs (still `skins: [Vector]`, so Vector stays the default). Verified separately that listing a non-Vector skin first (e.g. `[Timeless]`) now produces a `skin-timeless` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)