### PR TITLE
feat: keep non-main skin pages out of search indexes

### DIFF
--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -203,6 +203,10 @@ if ($wikvenBuildSkin !== false && in_array($wikvenBuildSkin, $wgWikvenSkins, tru
 	if ($wikvenBuildSkin !== $wgWikvenMainSkin) {
 		$wgWikvenHtmlDirectory = "$wikvenDist/$wikvenBuildSkin";
 		$wgFileCacheDirectory = $wgWikvenHtmlDirectory;
+		// Non-main skins are duplicate copies of the main skin's pages, so keep
+		// them out of search indexes (only the main skin at the dist root is
+		// indexed). Read at render time, so RebuildFileCache emits it.
+		$wgDefaultRobotPolicy = 'noindex,follow';
 	}
 }
 


### PR DESCRIPTION
## What

On non-main skin build passes, set `$wgDefaultRobotPolicy = 'noindex,follow'`. Only the main skin (at the dist root) stays indexable; the duplicate per-skin copies under `dist/<skin>/` are excluded from search indexes.

## Why

Each non-main skin is a full duplicate of the main skin's pages. Without this, crawlers would index the same content N times (duplicate content). #107.

## Test

Local `skins: [Vector, Timeless]` build:

- `dist/timeless/Main_Page.html` → `<meta name="robots" content="noindex,follow,...">`
- `dist/Main_Page.html` (root/main) → no `noindex` (indexable)
- `dist/Search.html` (root) → `noindex` preserved via `__NOINDEX__`
- `dist/timeless/Search.html` → `noindex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)