### PR TITLE
feat: add a footer skin switcher

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -6,6 +6,7 @@ extensions:
   - SifterSearch
 skins:
   - Vector
+  - Timeless
 config:
   WikvenFooterUrl: https://github.com/chaotic-ground/wikven
   WikvenEditUrl: https://github.com/chaotic-ground/wikven/edit/main/docs/$1

--- a/extension.json
+++ b/extension.json
@@ -19,6 +19,9 @@
 		"ext.Wikven.pinnableState": {
 			"scripts": ["pinnable-state.js"],
 			"dependencies": ["mediawiki.storage"]
+		},
+		"ext.Wikven.skinSwitcher": {
+			"scripts": ["skin-switcher.js"]
 		}
 	},
 	"ResourceModuleSkinStyles": {

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -18,20 +18,52 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 		if (!ExtensionRegistry::getInstance()->isLoaded('SifterSearch')) {
 			$out->addInlineStyle('#p-search { display: none; }');
 		}
+
+		// With more than one enabled skin, the footer carries a skin switcher.
+		if (count($GLOBALS['wgWikvenSkins'] ?? []) > 1) {
+			$out->addModules('ext.Wikven.skinSwitcher');
+			$out->addJsConfigVars('wgWikvenMainSkin', $GLOBALS['wgWikvenMainSkin'] ?? '');
+		}
 	}
 
 	/** @inheritDoc */
 	public function onSkinAddFooterLinks(Skin $skin, string $key, array &$footerItems) {
-		global $wgWikvenFooterUrl;
+		global $wgWikvenFooterUrl, $wgWikvenSkins;
 
-		if ($key !== 'places' || !$wgWikvenFooterUrl) {
+		if ($key !== 'places') {
 			return;
 		}
-		$footerItems['github'] = Html::element(
-			'a',
-			['href' => $wgWikvenFooterUrl],
-			// TODO: it could not be Github.
-			'View project on Github'
+		if ($wgWikvenFooterUrl) {
+			$footerItems['github'] = Html::element(
+				'a',
+				['href' => $wgWikvenFooterUrl],
+				// TODO: it could not be Github.
+				'View project on Github'
+			);
+		}
+		if (count($wgWikvenSkins ?? []) > 1) {
+			$footerItems['skin-switcher'] = $this->skinSwitcher($wgWikvenSkins, $skin->getSkinName());
+		}
+	}
+
+	/**
+	 * A footer <select> linking to the other enabled skins' copies of the current
+	 * page. The ext.Wikven.skinSwitcher module wires the navigation; without it
+	 * the control is an inert list of the available skins.
+	 */
+	private function skinSwitcher(array $skins, string $current): string {
+		$options = '';
+		foreach ($skins as $name) {
+			$attribs = ['value' => $name];
+			if ($name === $current) {
+				$attribs['selected'] = '';
+			}
+			$options .= Html::element('option', $attribs, ucwords(str_replace('-', ' ', $name)));
+		}
+		return Html::rawElement(
+			'label',
+			['class' => 'wikven-skin-switcher'],
+			'Skin: ' . Html::rawElement('select', [], $options)
 		);
 	}
 }

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -1,3 +1,6 @@
+// Codex design tokens, so the skin switcher matches the active skin's theme.
+@import 'mediawiki.skin.variables.less';
+
 // Footer: the project (about/disclaimer/privacy) pages do not exist in the
 // static export, so hide those links. The "disclaimers" id is plural.
 #footer-places-privacy,
@@ -25,4 +28,22 @@
 
 a.new {
   pointer-events: none;
+}
+
+// Skin switcher: a native select styled with design tokens so it reads as a
+// regular MediaWiki form control across skins.
+.wikven-skin-switcher {
+  display: inline-flex;
+  align-items: center;
+
+  select {
+    margin-left: @spacing-50;
+    padding: @spacing-25 @spacing-75;
+    border: @border-width-base @border-style-base @border-color-base;
+    border-radius: @border-radius-base;
+    background-color: @background-color-base;
+    color: @color-base;
+    font: inherit;
+    cursor: pointer;
+  }
 }

--- a/resources/skin-switcher.js
+++ b/resources/skin-switcher.js
@@ -1,0 +1,49 @@
+/**
+ * Navigate between the per-skin copies of the static export.
+ *
+ * The build renders each enabled skin into its own output: the main skin at the
+ * dist root, every other skin under dist/<skin>/. The footer holds a <select> of
+ * the enabled skins (rendered by the SkinAddFooterLinks hook); this wires it so
+ * choosing a skin loads the same page from that skin's copy. Internal links are
+ * relative, so once the reader is inside a skin's subtree they stay there.
+ *
+ * The choice is not persisted: a fresh visit lands on whatever URL was opened
+ * (the indexed main skin at the root). On a plain static host there is no way to
+ * redirect to a stored skin without a flash, so the switch stays explicit.
+ */
+(() => {
+	const main = mw.config.get("wgWikvenMainSkin");
+	const current = mw.config.get("skin");
+
+	// Map the current page's URL to the same page under another skin. The skin
+	// dir is the only segment that differs: the main skin has none, others sit in
+	// a "<skin>/" subdirectory right under the shared base.
+	const targetUrl = (target) => {
+		const path = location.pathname;
+		const slash = path.lastIndexOf("/");
+		const file = path.slice(slash + 1);
+		let base = path.slice(0, slash + 1);
+		if (current !== main && base.endsWith(`/${current}/`)) {
+			base = base.slice(0, base.length - current.length - 1);
+		}
+		const prefix = target === main ? "" : `${target}/`;
+		return base + prefix + file + location.search + location.hash;
+	};
+
+	const init = () => {
+		const selects = document.querySelectorAll(".wikven-skin-switcher select");
+		for (const select of selects) {
+			select.addEventListener("change", () => {
+				if (select.value && select.value !== current) {
+					location.assign(targetUrl(select.value));
+				}
+			});
+		}
+	};
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", init);
+	} else {
+		init();
+	}
+})();


### PR DESCRIPTION
## What

- When more than one skin is enabled, the footer (`SkinAddFooterLinks`, `places` group) renders a `Skin:` `<select>` of the enabled skins, current one preselected.
- New `ext.Wikven.skinSwitcher` module navigates to the same page under the chosen skin's copy: the main skin at the dist root, others under `dist/<skin>/`. Since internal links are relative, the reader stays in that skin while browsing.
- Dogfood: docs now build on `[Vector, Timeless]`, so the switcher is live.

The choice is **not** persisted (manual switcher): a fresh visit lands on the indexed main skin at the root, and a plain static host cannot redirect to a stored skin without a visible flash. Searching from a non-main skin also lands on the main skin (Pagefind result URLs are root-relative) — a documented limitation.

## Test

Local `[Vector, Timeless]` build, served and driven in a browser:

- Switcher renders and is visible in the footer of both Vector and Timeless.
- Vector `Getting_Started.html` → pick Timeless → `/timeless/Getting_Started.html` (skin `timeless`).
- Timeless → pick Vector → back to root `/Getting_Started.html` (skin `vector-2022`).
- Directory URL `/wikven/` → pick Timeless → `/wikven/timeless/`.
- Current skin is preselected in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)