### PR TITLE
feat: offer the Citizen skin (search hidden)

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -7,6 +7,7 @@ extensions:
 skins:
   - Vector
   - Timeless
+  - Citizen
 config:
   WikvenFooterUrl: https://github.com/chaotic-ground/wikven
   WikvenEditUrl: https://github.com/chaotic-ground/wikven/edit/main/docs/$1
@@ -35,6 +36,12 @@ config:
     TabberNeue:
       repository: https://github.com/StarCitizenTools/mediawiki-extensions-TabberNeue.git
       reference: v4.0.0
+    # Citizen is a third-party skin; its search is its own REST-backed command
+    # palette, which has no backend on a static export, so it is hidden (see
+    # Adder.php). The other skins keep working SifterSearch search.
+    Citizen:
+      repository: https://github.com/StarCitizenTools/mediawiki-skins-Citizen.git
+      reference: v3.17.0
     # The rolling nightly tarball bundles the Pagefind binary (a git clone omits
     # it). No sha256: it rolls, so a SifterSearch change is picked up by
     # triggering the nightly and rebuilding, with no re-pin here.

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -24,6 +24,16 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 			$out->addModules('ext.Wikven.skinSwitcher');
 			$out->addJsConfigVars('wgWikvenMainSkin', $GLOBALS['wgWikvenMainSkin'] ?? '');
 		}
+
+		// Citizen's search is its own REST-backed command palette, which has no
+		// backend on the static export; hide its trigger there. SifterSearch does
+		// not wire Citizen, so there is no Pagefind-backed replacement. A live wiki
+		// (web entry) keeps Citizen's search working, so only hide it on the build.
+		if (MW_ENTRY_POINT === 'cli' && $skin->getSkinName() === 'citizen') {
+			// !important: the element also carries .citizen-dropdown, whose
+			// display:flex would otherwise win by cascade order.
+			$out->addInlineStyle('.citizen-search { display: none !important; }');
+		}
 	}
 
 	/** @inheritDoc */


### PR DESCRIPTION
## What

Add **Citizen** (third-party, fetched from Git via `WikvenRepositories` at `v3.17.0`) as a third dogfood skin, so the docs offer Vector + Timeless + Citizen.

Citizen disables MediaWiki's standard search wiring (`$config['search'] = false`) and uses its own REST-backed command palette. SifterSearch therefore cannot wire it, and there is no REST backend on a static export, so its search trigger (`.citizen-search`) is hidden on the build (`MW_ENTRY_POINT === 'cli'`). A live wiki keeps Citizen's search working. Vector and Timeless keep working Pagefind search.

## Why

#107 multi-skin: showcase wikven's skin flexibility + third-party skin fetching.

## Test

Local `[Vector, Timeless, Citizen]` build, served and inspected:

- Citizen builds into `dist/citizen/` (`skin-citizen`), cloned from `v3.17.0`.
- The hide style lands only on `dist/citizen/*.html`, not Vector/Timeless.
- On a Citizen page the native search trigger is `display: none` (computed) — `!important` is needed because the element also carries `.citizen-dropdown` (`display: flex`).
- The footer skin switcher works on Citizen (Vector / Timeless / Citizen, current preselected).

> Note: a separate pre-existing issue (the full-results Pagefind widget mounting on every page via the combined static bundle) is unrelated to this PR and affects all skins; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)