### PR TITLE
feat: point non-main skin pages' canonical at the main copy

### DIFF
--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -112,6 +112,24 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 				}
 			}
 		}
+
+		// Non-main skins render duplicate copies of every page under dist/<skin>/.
+		// Point their canonical link at the main skin's copy one directory up (the
+		// dist root) so crawlers dedupe to it.
+		$mainSkin = $GLOBALS['wgWikvenMainSkin'] ?? null;
+		$title = $out->getTitle();
+		if (
+			MW_ENTRY_POINT === 'cli'
+			&& $mainSkin
+			&& $title
+			&& $out->getSkin()->getSkinName() !== $mainSkin
+		) {
+			$name = Title::makeName($title->getNamespace(), $title->getDBkey());
+			$tags['link-canonical'] = Html::element('link', [
+				'rel' => 'canonical',
+				'href' => "../$name.html"
+			]);
+		}
 	}
 
 	private function addStyleToList(string $name): void {


### PR DESCRIPTION
## What

Non-main skins render duplicate copies of every page under `dist/<skin>/`. On those build passes, emit `<link rel="canonical" href="../<page>.html">` so crawlers dedupe to the main skin's copy at the dist root, on top of the `noindex` they already carry (#113).

Implemented in `Main::onOutputPageAfterGetHeadLinksArray`, gated on `MW_ENTRY_POINT === 'cli'` and the current skin not being `$wgWikvenMainSkin`. Main-skin pages and live wikis are unaffected.

## Test

Local `[Vector, Timeless, Citizen]` build:

- `dist/timeless/Getting_Started.html` → `<link rel="canonical" href="../Getting_Started.html">`
- `dist/timeless/index.html` → `../index.html`; `dist/timeless/Search.html` → `../Search.html`
- `dist/citizen/*` likewise
- `dist/Getting_Started.html` (main) → no canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)