### PR TITLE
feat: generate a Special:Version-style page linked from the footer

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -63,6 +63,10 @@
 			"value": "index",
 			"description": "Title of the page used as the wiki's main page, i.e. the static site root (written as <value>.html). Must be an imported page."
 		},
+		"WikvenVersionPage": {
+			"value": "Version",
+			"description": "Title of an auto-generated page (mirroring Special:Version) listing the installed software, extensions and skins, linked from the footer. Empty disables it; a same-named source page takes precedence."
+		},
 		"WikvenHtmlDirectory": {
 			"value": "/workspace/dist",
 			"description": "Path to the dist directory of HTML files."

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\Wikven\Hooks;
 use MediaWiki\Html\Html;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Skin\Skin;
+use MediaWiki\Title\Title;
 
 class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\SkinAddFooterLinksHook {
 	/** @inheritDoc */
@@ -38,7 +39,7 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 
 	/** @inheritDoc */
 	public function onSkinAddFooterLinks(Skin $skin, string $key, array &$footerItems) {
-		global $wgWikvenFooterUrl, $wgWikvenSkins;
+		global $wgWikvenFooterUrl, $wgWikvenSkins, $wgWikvenVersionPage;
 
 		if ($key !== 'places') {
 			return;
@@ -50,6 +51,17 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 				// TODO: it could not be Github.
 				'View project on Github'
 			);
+		}
+		$versionPage = $wgWikvenVersionPage ?? '';
+		if ($versionPage !== '') {
+			$versionTitle = Title::newFromText($versionPage);
+			if ($versionTitle && $versionTitle->exists()) {
+				$footerItems['version'] = Html::element(
+					'a',
+					['href' => $versionTitle->getLocalURL()],
+					'Version'
+				);
+			}
 		}
 		if (count($wgWikvenSkins ?? []) > 1) {
 			$footerItems['skin-switcher'] = $this->skinSwitcher($wgWikvenSkins, $skin->getSkinName());

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -6,6 +6,7 @@ use ImportImages;
 use Maintenance;
 use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Content\ContentHandler;
+use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
@@ -56,6 +57,7 @@ class Build extends Maintenance {
 		$this->importImages("$ip/maintenance/importImages.php");
 		$this->step(ImportWikitext::class, "$own/importWikitext.php");
 		$this->assertMainPageExists();
+		$this->setVersionPage();
 		$this->step(RunJobs::class, "$ip/maintenance/runJobs.php");
 
 		$skins = $GLOBALS['wgWikvenSkins'] ?? [];
@@ -215,6 +217,56 @@ class Build extends Maintenance {
 		$content = ContentHandler::makeContent($GLOBALS['wgWikvenMainPage'], $title);
 		$updater->setContent(SlotRecord::MAIN, $content);
 		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Set the main page'));
+	}
+
+	/**
+	 * Generate a Version page (mirroring Special:Version, which a static export
+	 * has no server to serve) listing the installed software, extensions and
+	 * skins. Skipped when $wgWikvenVersionPage is empty or the site already
+	 * provides a same-named page.
+	 */
+	private function setVersionPage(): void {
+		$name = $GLOBALS['wgWikvenVersionPage'] ?? 'Version';
+		if ($name === '') {
+			return;
+		}
+		$title = Title::newFromText($name);
+		if (!$title || $title->exists()) {
+			return;
+		}
+
+		$db = $this->getServiceContainer()->getConnectionProvider()->getReplicaDatabase();
+		$software = [
+			['[https://www.mediawiki.org/ MediaWiki]', MW_VERSION],
+			['[https://www.php.net/ PHP]', PHP_VERSION . ' (' . PHP_SAPI . ')'],
+			[ucfirst($db->getType()), $db->getServerVersion()]
+		];
+
+		$text = "__NOINDEX__\n";
+		$text .= "This site is generated with the following open-source software.\n\n";
+		$text .= "== Installed software ==\n";
+		$text .= "{| class=\"wikitable\"\n! Product !! Version\n";
+		foreach ($software as [$product, $version]) {
+			$text .= "|-\n| $product\n| $version\n";
+		}
+		$text .= "|}\n\n";
+
+		$text .= "== Installed extensions and skins ==\n";
+		$text .= "{| class=\"wikitable\"\n! Name !! Version\n";
+		$things = ExtensionRegistry::getInstance()->getAllThings();
+		ksort($things);
+		foreach ($things as $thingName => $credits) {
+			$url = $credits['url'] ?? '';
+			$label = $url !== '' ? "[$url $thingName]" : $thingName;
+			$text .= "|-\n| $label\n| " . ( $credits['version'] ?? '' ) . "\n";
+		}
+		$text .= "|}\n";
+
+		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
+		$updater = $page->newPageUpdater($user);
+		$updater->setContent(SlotRecord::MAIN, ContentHandler::makeContent($text, $title));
+		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Generate the version page'));
 	}
 
 	/**


### PR DESCRIPTION
## What

A static export has no server to serve `Special:Version`, so generate a content page at build time that mirrors it: it lists the installed software (MediaWiki, PHP, database) and every registered extension and skin with its version and project link, and is linked from the footer.

- New `$wgWikvenVersionPage` config (default `"Version"`; empty disables; a same-named source page takes precedence).
- Generated in `maintenance/build.php` during the one-time wiki population (before the per-skin render), so it renders per skin like any content page, carries the footer skin switcher + `rel=canonical`, and is `__NOINDEX__`'d.
- Footer "Version" link added in `Adder.php`.

## Why

Show readers the open-source stack behind the site, as `Special:Version` does on a live wiki. #107 follow-up.

## Test

Local `[Vector, Timeless, Citizen]` build:

- `dist/Version.html` + `dist/<skin>/Version.html` generated.
- Renders an "Installed software" table (MediaWiki 1.45.3, PHP 8.3.31, Sqlite 3.46.1) and an "Installed extensions and skins" table (Citizen 3.17.0, SifterSearch, TabberNeue 4.0.0, Vector, Timeless, …) with project links.
- Footer "Version" link present and resolves per skin; page is in the noindex tracking category.

> Note: bundled-but-unconfigured skins (MinervaNeue, MonoBook) also appear because the MediaWiki installer loads every bundled skin — faithful to `Special:Version`, which lists all loaded components. Can be filtered to only enabled skins if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)