### PR TITLE
feat: add a "View source" tab linking to the repo source

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -12,6 +12,7 @@ config:
   WikvenFooterUrl: https://github.com/chaotic-ground/wikven
   WikvenEditUrl: https://github.com/chaotic-ground/wikven/edit/main/docs/$1
   WikvenHistoryUrl: https://github.com/chaotic-ground/wikven/commits/main/docs/$1
+  WikvenViewSourceUrl: https://github.com/chaotic-ground/wikven/blob/main/docs/$1
   WikvenLogos:
     icon: logo.svg
   # Search results have no thumbnails, so drop the empty thumbnail column from

--- a/extension.json
+++ b/extension.json
@@ -35,7 +35,7 @@
 	},
 	"Hooks": {
 		"ParserOutputPostCacheTransform": "hider",
-		"SkinTemplateNavigation::Universal": "hider",
+		"SkinTemplateNavigation::Universal": ["hider", "main"],
 		"SidebarBeforeOutput": "hider",
 		"SkinAddFooterLinks": "adder",
 		"BeforePageDisplay": "adder",
@@ -90,6 +90,10 @@
 		"WikvenHistoryUrl": {
 			"value": "",
 			"description": "URL template for the per-page \"View history\" link. $1 is replaced with the page's percent-encoded source file name, as for WikvenEditUrl. Empty disables the link."
+		},
+		"WikvenViewSourceUrl": {
+			"value": "",
+			"description": "URL template for the per-page \"View source\" tab, linking to the page's source file in the repository. $1 is replaced with the page's percent-encoded source file name, as for WikvenEditUrl. Empty disables the tab."
 		},
 		"WikvenLogos": {
 			"value": [],

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -12,7 +12,10 @@ use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
 use MediaWiki\Title\Title;
 
-class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPageAfterGetHeadLinksArrayHook {
+class Main implements
+	\MediaWiki\Hook\GetLocalURLHook,
+	\MediaWiki\Hook\OutputPageAfterGetHeadLinksArrayHook,
+	\MediaWiki\Hook\SkinTemplateNavigation__UniversalHook {
 	private ?Context $rlClientContext = null;
 
 	/** The directory the HTML files are written to. */
@@ -54,25 +57,31 @@ class Main implements \MediaWiki\Hook\GetLocalURLHook, \MediaWiki\Hook\OutputPag
 		// For edit/history, $1 is the page's source filename, so the link lands
 		// on the file to edit rather than the rendered page.
 		if ($action === 'edit' && $wgWikvenEditUrl) {
-			$url = str_replace('$1', $this->sourceFileParam($title), $wgWikvenEditUrl);
+			$url = str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $wgWikvenEditUrl);
 		} elseif ($action === 'history' && $wgWikvenHistoryUrl) {
-			$url = str_replace('$1', $this->sourceFileParam($title), $wgWikvenHistoryUrl);
+			$url = str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $wgWikvenHistoryUrl);
 		} else {
 			$url = "./$name.html";
 		}
 	}
 
 	/**
-	 * The source file a page imported from, percent-encoded for use as the $1 in
-	 * WikvenEditUrl/WikvenHistoryUrl. Built from the title text (spaces, not the
-	 * DB key's underscores) so it matches the on-disk file name, then encoded so
-	 * characters legal in a title but unsafe in a URL path (spaces, '#', '?',
-	 * '%', non-ASCII) cannot break or truncate the link. The subpage separator
-	 * '/' and the namespace separator ':' are kept readable.
+	 * Add a "View source" tab linking to the page's source file in the repository
+	 * ($wgWikvenViewSourceUrl, with $1 the source file name), the read-only
+	 * counterpart of the Edit tab. Skipped when the URL is not configured.
+	 *
+	 * @inheritDoc
 	 */
-	private function sourceFileParam(Title $title): string {
-		$file = SourceFile::titleToFilename($title->getPrefixedText());
-		return strtr(rawurlencode($file), ['%2F' => '/', '%3A' => ':']);
+	public function onSkinTemplateNavigation__Universal($sktemplate, &$links): void {
+		global $wgWikvenViewSourceUrl;
+		$title = $sktemplate->getTitle();
+		if (!$wgWikvenViewSourceUrl || !$title || !$title->canExist()) {
+			return;
+		}
+		$links['views']['wikven-viewsource'] = [
+			'text' => 'View source',
+			'href' => str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $wgWikvenViewSourceUrl)
+		];
 	}
 
 	/** @inheritDoc */

--- a/includes/SourceFile.php
+++ b/includes/SourceFile.php
@@ -66,6 +66,18 @@ class SourceFile {
 	}
 
 	/**
+	 * The source file name of a page, percent-encoded for use as the $1 in the
+	 * edit/history/view-source URL templates. Built from the prefixed title text
+	 * (spaces, not the DB key's underscores) so it matches the on-disk file name,
+	 * then encoded so characters legal in a title but unsafe in a URL path
+	 * (spaces, '#', '?', '%', non-ASCII) cannot break or truncate the link. The
+	 * subpage separator '/' and the namespace separator ':' are kept readable.
+	 */
+	public static function titleToParam(string $titleText): string {
+		return strtr(rawurlencode(self::titleToFilename($titleText)), ['%2F' => '/', '%3A' => ':']);
+	}
+
+	/**
 	 * Whether MediaWiki resolves a non-wikitext default content model for the
 	 * given title text — i.e. the title (via its extension or namespace) already
 	 * determines the content, so no ".wikitext" marker is needed. Driven by the


### PR DESCRIPTION
## What

The Edit tab opens the repository's edit view. This adds a read-only **View source** tab next to it that links to the page's source file in the repository, like a wiki's "View source" but pointing at the repo instead of the wikitext.

- New `$wgWikvenViewSourceUrl` config (URL template, `$1` = source file name; empty disables the tab).
- Added via `Main::onSkinTemplateNavigation__Universal` into the `views` group.
- The source-file param (title → percent-encoded file name) shared by the edit, history and view-source links moves to `SourceFile::titleToParam`.
- docs build sets it to the GitHub `blob` URL.

## Test

Local `[Vector, Timeless, Citizen]` build:

- Nav shows **Read | Edit | View history | View source | Tools**; the tab is visible and labelled "View source".
- Links to e.g. `https://github.com/chaotic-ground/wikven/blob/main/docs/Getting%20Started.wikitext`.
- `php -l`, `mago`, `biome` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
