### PR TITLE
feat: use the core viewsource message for the View source tab

### DIFF
--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -79,7 +79,8 @@ class Main implements
 			return;
 		}
 		$links['views']['wikven-viewsource'] = [
-			'text' => 'View source',
+			// MediaWiki core's existing "View source" label, so it is translated.
+			'text' => $sktemplate->msg('viewsource')->text(),
 			'href' => str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $wgWikvenViewSourceUrl)
 		];
 	}


### PR DESCRIPTION
## What

The View source tab text was hardcoded `'View source'`. Use MediaWiki core's existing `viewsource` message (`$sktemplate->msg('viewsource')`) so the label is translated with the wiki's language.

## Why

i18n: the tab now follows the site language like every other MediaWiki UI label, with no new message of our own.

## Test

- Confirmed `viewsource` is a core message (`languages/i18n/en.json`: `"viewsource": "View source"`), so the English label is unchanged and other languages get core's translation.
- `php -l`, `mago` clean.
- (Skipped the local Docker render this round to avoid OOM; the message key is verified against core and CI builds the image.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)