### PR TITLE
fix: hide the category footer on the static export

### DIFF
--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -30,6 +30,13 @@ a.new {
   pointer-events: none;
 }
 
+// Category links go to Category: pages, which a static export does not render
+// (only content namespaces are cached), so the whole footer is dead links plus
+// noise like the __NOINDEX__ tracking category. Hide it.
+#catlinks {
+  display: none;
+}
+
 // Skin switcher: a native select styled with design tokens so it reads as a
 // regular MediaWiki form control across skins.
 .wikven-skin-switcher {


### PR DESCRIPTION
## What

Hide `#catlinks` (the category footer) on the static export.

## Why

Category links point at `Category:` pages, which the static export does not render (only the content namespaces `[0, 6]` are file-cached), so every category link is a dead link. The only categories that currently appear are MediaWiki tracking categories — e.g. the `__NOINDEX__` "Noindexed pages" category shown at the bottom of the **Search** and **Version** pages — which are internal noise.

## Test

- `#catlinks` is the standard core-rendered category container (confirmed in `dist/Search.html`); the rule hides it across skins.
- Pages without categories already render an empty `#catlinks`, so hiding it is a no-op there.
- (Skipped the local Docker render this round to avoid OOM; the change is a single static CSS rule and CI builds the image.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)