### PR TITLE
fix: stop suppressing real categories; drop Version __NOINDEX__

### DIFF
--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -242,8 +242,7 @@ class Build extends Maintenance {
 			[ucfirst($db->getType()), $db->getServerVersion()]
 		];
 
-		$text = "__NOINDEX__\n";
-		$text .= "This site is generated with the following open-source software.\n\n";
+		$text = "This site is generated with the following open-source software.\n\n";
 		$text .= "== Installed software ==\n";
 		$text .= "{| class=\"wikitable\"\n! Product !! Version\n";
 		foreach ($software as [$product, $version]) {

--- a/resources/ext.Wikven.styles.less
+++ b/resources/ext.Wikven.styles.less
@@ -30,13 +30,6 @@ a.new {
   pointer-events: none;
 }
 
-// Category links go to Category: pages, which a static export does not render
-// (only content namespaces are cached), so the whole footer is dead links plus
-// noise like the __NOINDEX__ tracking category. Hide it.
-#catlinks {
-  display: none;
-}
-
 // Skin switcher: a native select styled with design tokens so it reads as a
 // regular MediaWiki form control across skins.
 .wikven-skin-switcher {


### PR DESCRIPTION
## What

Reverts the blanket `#catlinks { display: none }` (#121), which also hid legitimate categories a site may use. Instead, only the noise is removed:

- The generated **Version** page no longer uses `__NOINDEX__`, so it doesn't add the "Noindexed pages" tracking category (it's just version info; being indexed is harmless).
- The **search results** page's category footer is hidden client-side by SifterSearch, on that page only (separate PR in SifterSearch).

MediaWiki's tracking-category mechanism is left untouched globally.

## Why

#121 was too broad — it suppressed all categories everywhere, not just the tracking-category noise. Real categories should still render.

## Test

- `php -l`, `mago` clean.
- (Local Docker render skipped to avoid OOM; changes are a CSS deletion + dropping one wikitext line from the generated page.)

> Pairs with SifterSearch PR (results-page category footer hidden after the widget mounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)