### PR TITLE
feat(i18n): translate the footer, skin switcher and version page strings

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,9 @@
+{
+	"@metadata": {
+		"authors": []
+	},
+	"wikven-skin-switcher-label": "Skin",
+	"wikven-footer-source": "View project on $1",
+	"wikven-footer-source-plain": "View project source",
+	"wikven-version-intro": "This site is generated with the following open-source software."
+}

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,0 +1,9 @@
+{
+	"@metadata": {
+		"authors": []
+	},
+	"wikven-skin-switcher-label": "Label preceding the skin switcher dropdown in the footer. Followed by {{msg-mw|colon-separator}}.",
+	"wikven-footer-source": "Footer link to the project's source repository. $1 is the repository host name (e.g. GitHub, GitLab) or a bare domain.",
+	"wikven-footer-source-plain": "Footer link to the project's source repository, used when no host can be derived from the URL.",
+	"wikven-version-intro": "Introductory sentence on the generated version page, which mirrors [[Special:Version]]."
+}

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Wikven\Hooks;
 
 use MediaWiki\Html\Html;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\Skin\Skin;
 use MediaWiki\Title\Title;
@@ -49,7 +50,9 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 			$footerItems['source'] = Html::element(
 				'a',
 				['href' => $wgWikvenFooterUrl],
-				$host !== null ? "View project on $host" : 'View project source'
+				$host !== null
+					? $skin->msg('wikven-footer-source', $host)->text()
+					: $skin->msg('wikven-footer-source-plain')->text()
 			);
 		}
 		$versionPage = $wgWikvenVersionPage ?? '';
@@ -59,12 +62,12 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 				$footerItems['version'] = Html::element(
 					'a',
 					['href' => $versionTitle->getLocalURL()],
-					'Version'
+					$skin->msg('version')->text()
 				);
 			}
 		}
 		if (count($wgWikvenSkins ?? []) > 1) {
-			$footerItems['skin-switcher'] = $this->skinSwitcher($wgWikvenSkins, $skin->getSkinName());
+			$footerItems['skin-switcher'] = $this->skinSwitcher($skin, $wgWikvenSkins, $skin->getSkinName());
 		}
 	}
 
@@ -95,19 +98,22 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 	 * page. The ext.Wikven.skinSwitcher module wires the navigation; without it
 	 * the control is an inert list of the available skins.
 	 */
-	private function skinSwitcher(array $skins, string $current): string {
+	private function skinSwitcher(Skin $skin, array $skins, string $current): string {
+		$displayNames = MediaWikiServices::getInstance()->getSkinFactory()->getInstalledSkins();
 		$options = '';
 		foreach ($skins as $name) {
 			$attribs = ['value' => $name];
 			if ($name === $current) {
 				$attribs['selected'] = '';
 			}
-			$options .= Html::element('option', $attribs, ucwords(str_replace('-', ' ', $name)));
+			$label = $displayNames[$name] ?? ucwords(str_replace('-', ' ', $name));
+			$options .= Html::element('option', $attribs, $label);
 		}
+		$label = $skin->msg('wikven-skin-switcher-label')->escaped() . $skin->msg('colon-separator')->text();
 		return Html::rawElement(
 			'label',
 			['class' => 'wikven-skin-switcher'],
-			'Skin: ' . Html::rawElement('select', [], $options)
+			$label . Html::rawElement('select', [], $options)
 		);
 	}
 }

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -242,30 +242,71 @@ class Build extends Maintenance {
 			[ucfirst($db->getType()), $db->getServerVersion()]
 		];
 
-		$text = "This site is generated with the following open-source software.\n\n";
-		$text .= "== Installed software ==\n";
-		$text .= "{| class=\"wikitable\"\n! Product !! Version\n";
+		$text = $this->contentMsg('wikven-version-intro') . "\n\n";
+		$text .= '== ' . $this->contentMsg('version-software') . " ==\n";
+		$text .=
+			"{| class=\"wikitable\"\n! "
+			. $this->contentMsg('version-software-product')
+			. ' !! '
+			. $this->contentMsg('version-software-version')
+			. "\n";
 		foreach ($software as [$product, $version]) {
 			$text .= "|-\n| $product\n| $version\n";
 		}
 		$text .= "|}\n\n";
 
-		$text .= "== Installed extensions and skins ==\n";
-		$text .= "{| class=\"wikitable\"\n! Name !! Version\n";
-		$things = ExtensionRegistry::getInstance()->getAllThings();
-		ksort($things);
-		foreach ($things as $thingName => $credits) {
-			$url = $credits['url'] ?? '';
-			$label = $url !== '' ? "[$url $thingName]" : $thingName;
-			$text .= "|-\n| $label\n| " . ( $credits['version'] ?? '' ) . "\n";
+		// Split the registered components into extensions and skins (skins live
+		// under skins/), each in its own section as Special:Version does.
+		$extensions = [];
+		$skins = [];
+		foreach (ExtensionRegistry::getInstance()->getAllThings() as $thingName => $credits) {
+			if (str_contains($credits['path'] ?? '', '/skins/')) {
+				$skins[$thingName] = $credits;
+			} else {
+				$extensions[$thingName] = $credits;
+			}
 		}
-		$text .= "|}\n";
+		$text .= $this->componentTable('version-extensions', 'version-ext-colheader-name', $extensions);
+		$text .= $this->componentTable('version-skins', 'version-skin-colheader-name', $skins);
 
 		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
 		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
 		$updater = $page->newPageUpdater($user);
 		$updater->setContent(SlotRecord::MAIN, ContentHandler::makeContent($text, $title));
 		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Generate the version page'));
+	}
+
+	/**
+	 * A message in the wiki's content language, for the generated version page
+	 * (which is content, not interface chrome, so it follows the site language).
+	 */
+	private function contentMsg(string $key): string {
+		return wfMessage($key)->inContentLanguage()->text();
+	}
+
+	/**
+	 * A wikitext table of installed components (extensions or skins) with their
+	 * versions and project links, under the given section/name-column messages.
+	 */
+	private function componentTable(string $headingKey, string $nameColKey, array $things): string {
+		if (!$things) {
+			return '';
+		}
+		ksort($things);
+		$text = '== ' . $this->contentMsg($headingKey) . " ==\n";
+		$text .=
+			"{| class=\"wikitable\"\n! "
+			. $this->contentMsg($nameColKey)
+			. ' !! '
+			. $this->contentMsg('version-ext-colheader-version')
+			. "\n";
+		foreach ($things as $thingName => $credits) {
+			$url = $credits['url'] ?? '';
+			$label = $url !== '' ? "[$url $thingName]" : $thingName;
+			$text .= "|-\n| $label\n| " . ( $credits['version'] ?? '' ) . "\n";
+		}
+		$text .= "|}\n";
+		return $text;
 	}
 
 	/**


### PR DESCRIPTION
## What

Replace the hardcoded English I'd added with proper messages, **reusing MediaWiki core messages** where they exist (as the View source tab already does), and add `i18n/en.json` + `i18n/qqq.json` (the `MessagesDirs` was already declared).

- **Footer**: "View project on …" → `wikven-footer-source` (`$1` = host) / `wikven-footer-source-plain`; the version link reuses core `version`.
- **Skin switcher**: label → `wikven-skin-switcher-label` + core `colon-separator`; option labels now come from `SkinFactory::getInstalledSkins()` display names instead of a hand-prettified slug.
- **Version page**: intro → `wikven-version-intro`; headings/column headers reuse core `version-software`, `version-software-product`, `version-software-version`, `version-extensions`, `version-skins`, `version-ext-colheader-name`, `version-skin-colheader-name`, `version-ext-colheader-version`. Extensions and skins are now split into separate sections (skins live under `skins/`), as Special:Version does.

## Why

Follow MediaWiki's i18n conventions so the UI follows the wiki language; don't reinvent messages core already ships translated.

## Test

- `php -l`, `mago`, `biome` (json) clean; core message keys verified present in `languages/i18n/en.json`; `en.json`/`qqq.json` keys match.
- (Local Docker render skipped to avoid OOM; CI builds the image. Worth a visual check on deploy: footer labels, switcher option names, and the split Installed extensions / Installed skins tables.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)