### PR TITLE
feat: persist the Docker/Binary tab choice across pages

### DIFF
--- a/docs/.wikven.yaml
+++ b/docs/.wikven.yaml
@@ -3,6 +3,7 @@ extensions:
   - ParserFunctions
   - TemplateStyles
   - TabberNeue
+  - Gadgets
   - SifterSearch
 skins:
   - Vector

--- a/docs/JavaScript.wikitext
+++ b/docs/JavaScript.wikitext
@@ -2,7 +2,7 @@
 
 == MediaWiki:Common.js ==
 
-Site-wide JavaScript lives in <code>MediaWiki:Common.js</code>, just like on a regular wiki. Create a <code>MediaWiki:Common.js.wikitext</code> file in your source directory and it runs on every page. The skin's <code>MediaWiki:Vector.js</code> (and so on) works the same way.
+Site-wide JavaScript lives in <code>MediaWiki:Common.js</code>, just like on a regular wiki. Create a <code>MediaWiki:Common.js</code> file in your source directory and it runs on every page. A <code>.js</code> page carries its own content model, so it needs no <code>.wikitext</code> marker. The skin's <code>MediaWiki:Vector.js</code> (and so on) works the same way.
 
 == Gadgets ==
 
@@ -13,13 +13,15 @@ extensions:
   - Gadgets
 </syntaxhighlight>
 
-List your gadgets in <code>MediaWiki:Gadgets-definition.wikitext</code>, and put each gadget's code in <code>MediaWiki:Gadget-<name>.js.wikitext</code>:
+List your gadgets in <code>MediaWiki:Gadgets-definition.wikitext</code>, and put each gadget's code in <code>MediaWiki:Gadget-<name>.js</code>:
 
 <syntaxhighlight lang="wikitext">
 * MyGadget[ResourceLoader|default]|MyGadget.js
 </syntaxhighlight>
 
 Only gadgets marked <code>default</code> are loaded: a static site has no logged-in readers to turn other gadgets on. A gadget's own CSS (in the same module) is included, but standalone styles-only gadgets are not yet covered.
+
+These docs ship one such gadget, <code>PersistTabber</code>, which remembers whether you pick the Docker or the binary tab in the install steps and keeps that choice as you move between pages.
 
 {{prevnext|Skins|Searching}}
 {{DISPLAYTITLE:JavaScript}}

--- a/docs/MediaWiki:Gadget-PersistTabber.js
+++ b/docs/MediaWiki:Gadget-PersistTabber.js
@@ -1,0 +1,99 @@
+/**
+ * Remember which tab a reader picks and apply it to every tabber, including on
+ * later pages. The install steps are shown in a Docker/Binary <tabber>; once a
+ * reader picks one, that choice should follow them across the site.
+ *
+ * The choice is stored by tab label, so tabbers that share a label (Docker,
+ * Binary, ...) stay in sync. TabberNeue dispatches a "tabber:tabchange" event
+ * and activates a tab on a plain click of its header link; this uses only those
+ * two and touches no TabberNeue internals.
+ */
+(() => {
+	const STORAGE_KEY = "wikven-tabber-choice";
+	// Set while we drive a tab change ourselves, so the change handler below does
+	// not treat it as a reader's selection.
+	let applying = false;
+
+	const readChoice = () => {
+		try {
+			return localStorage.getItem(STORAGE_KEY);
+		} catch {
+			// Storage can be unavailable (private mode, blocked cookies).
+			return null;
+		}
+	};
+
+	const writeChoice = (label) => {
+		try {
+			localStorage.setItem(STORAGE_KEY, label);
+		} catch {
+			// Best effort: without storage the choice just does not persist.
+		}
+	};
+
+	const tabLabel = (tab) => (tab.textContent || "").trim();
+
+	// Activate a tab the way a click would, minus the header link's default jump
+	// to the panel anchor (which would scroll the page). TabberNeue binds its
+	// click handler lazily, when a tabber first scrolls into view, so an early
+	// call is a harmless no-op and the caller retries until it takes.
+	const selectTab = (tab) => {
+		const href = tab.getAttribute("href");
+		if (href !== null) {
+			tab.removeAttribute("href");
+		}
+		applying = true;
+		tab.click();
+		applying = false;
+		if (href !== null) {
+			tab.setAttribute("href", href);
+		}
+		return tab.getAttribute("aria-selected") === "true";
+	};
+
+	const applyChoice = (label, attempt) => {
+		if (!label) {
+			return;
+		}
+		let pending = false;
+		for (const tab of document.querySelectorAll(".tabber__tab")) {
+			if (
+				tabLabel(tab) !== label ||
+				tab.getAttribute("aria-selected") === "true"
+			) {
+				continue;
+			}
+			if (!selectTab(tab)) {
+				pending = true;
+			}
+		}
+		// A wanted tab has not switched yet: its tabber is not live. Retry for a
+		// short while (about half a second at 60fps), then give up.
+		if (pending && attempt < 30) {
+			requestAnimationFrame(() => applyChoice(label, attempt + 1));
+		}
+	};
+
+	// Save and propagate the reader's own selection.
+	document.documentElement.addEventListener("tabber:tabchange", (e) => {
+		if (applying) {
+			return;
+		}
+		const source = e.detail?.source;
+		if (source !== "user-click" && source !== "user-keyboard") {
+			return;
+		}
+		const tab = e.target.querySelector(
+			":scope > .tabber__header > .tabber__tabs > .tabber__tab[aria-selected='true']",
+		);
+		if (!tab) {
+			return;
+		}
+		const label = tabLabel(tab);
+		writeChoice(label);
+		applyChoice(label, 0);
+	});
+
+	// Line every tabber up with the stored choice on each (re)render.
+	mw.hook("wikipage.content").add(() => applyChoice(readChoice(), 0));
+})();

--- a/docs/MediaWiki:Gadgets-definition.wikitext
+++ b/docs/MediaWiki:Gadgets-definition.wikitext
@@ -1,0 +1,1 @@
+* PersistTabber[ResourceLoader|default]|PersistTabber.js


### PR DESCRIPTION
## What

A reader who picks the **Docker** or **Binary** tab in the install steps now keeps that choice as they move between pages. The choice is stored by tab label in `localStorage` and re-applied to every tabber on load, so any tabbers sharing a label stay in sync.

This is delivered as a default-on gadget, which doubles as the docs' first real example of wikven's gadget support (already wired through `buildScripts.php`, just never exercised).

## Changes (`docs/`)

- **`MediaWiki:Gadget-PersistTabber.js`** (new) — the gadget. It uses only TabberNeue v4's public surface: it listens for the `tabber:tabchange` event to capture a reader's selection, and activates a tab by clicking its header link (TabberNeue's own handler does the switch). No internals touched.
  - Guards against reacting to its own programmatic changes.
  - Temporarily drops the link's `href` during a programmatic click so the page doesn't scroll-jump to the panel anchor.
  - TabberNeue binds its click handler lazily (on viewport entry), so the initial apply retries on `requestAnimationFrame` until the tabber is live, then gives up after ~0.5s.
- **`MediaWiki:Gadgets-definition.wikitext`** (new) — registers `PersistTabber` as a `default` ResourceLoader gadget so the build bundles it onto every page.
- **`.wikven.yaml`** — enable the bundled `Gadgets` extension.
- **`JavaScript.wikitext`** — fix inaccurate filename guidance: a `MediaWiki:*.js` page carries its own content model (like the existing `MediaWiki:Common.css`), so it takes no `.wikitext` marker; the old text would trigger import round-trip warnings. Also note the live `PersistTabber` example.

## Note

Only **Getting Started** currently has a Docker/Binary tabber, so the cross-page effect isn't visible anywhere yet. The gadget is general and ready; converting the install/build snippets on **Binary** and **Development** to the same tabber would exercise it (happy to do that here or in a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


BEGIN_COMMIT_OVERRIDE
docs: persist the Docker/Binary tab choice across pages
END_COMMIT_OVERRIDE
