### PR TITLE
build(deps-dev): update mediawiki/mediawiki-phan-config requirement from 0.17.0 to 0.18.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "51.0.0",
-		"mediawiki/mediawiki-phan-config": "0.17.0",
+		"mediawiki/mediawiki-phan-config": "0.18.0",
 		"mediawiki/minus-x": "2.0.1",
 		"phpro/grumphp": "2.21.0"
 	},


### PR DESCRIPTION
The most we can raise `mediawiki/mediawiki-phan-config` right now. 0.18.0 is the last release on phan 5.x; phan 5.5.2 resolves cleanly by taking `symfony/console` v7.

0.19+ (incl. #126's 0.20) move to phan 6.x, which the Wikimedia phan CI image cannot run yet — it ships php-ast 1.1.2 and phan 6 needs 1.1.3+. #126 is parked as a draft until the image updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)