### PR TITLE
fix: hide edit/history/source links on generated pages

### DIFF
--- a/includes/Hooks/Hider.php
+++ b/includes/Hooks/Hider.php
@@ -2,6 +2,8 @@
 
 namespace MediaWiki\Extension\Wikven\Hooks;
 
+use MediaWiki\Extension\Wikven\SourceFile;
+
 class Hider implements
 	\MediaWiki\Hook\ParserOutputPostCacheTransformHook,
 	\MediaWiki\Hook\SidebarBeforeOutputHook,
@@ -34,14 +36,17 @@ class Hider implements
 		}
 
 		// The edit and history tabs only make sense when they point at the
-		// external URLs configured via $wgWikvenEditUrl / $wgWikvenHistoryUrl.
-		// Without those, GetLocalURL falls back to a self-link (./Page.html),
-		// so drop the tabs instead of rendering dead links.
+		// external URLs configured via $wgWikvenEditUrl / $wgWikvenHistoryUrl, and
+		// at a page with a source file behind them. A generated page (e.g.
+		// Version) has none, so its links would 404; without the URLs, GetLocalURL
+		// falls back to a self-link (./Page.html). Drop the tabs in either case.
 		global $wgWikvenEditUrl, $wgWikvenHistoryUrl;
-		if (!$wgWikvenEditUrl) {
+		$title = $sktemplate->getTitle();
+		$hasSource = $title && SourceFile::exists($title->getPrefixedText());
+		if (!$wgWikvenEditUrl || !$hasSource) {
 			unset($links['views']['edit'], $links['views']['ve-edit'], $links['views']['viewsource']);
 		}
-		if (!$wgWikvenHistoryUrl) {
+		if (!$wgWikvenHistoryUrl || !$hasSource) {
 			unset($links['views']['history']);
 		}
 	}

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -77,7 +77,10 @@ class Main implements
 		$title = $sktemplate->getTitle();
 		// A generated page (e.g. Version) has no source file, so its source link
 		// would 404 in the repository; skip it as if the URL were unconfigured.
-		if (!$wgWikvenViewSourceUrl || !$title || !$title->canExist()
+		if (
+			!$wgWikvenViewSourceUrl
+			|| !$title
+			|| !$title->canExist()
 			|| !SourceFile::exists($title->getPrefixedText())
 		) {
 			return;

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -75,7 +75,11 @@ class Main implements
 	public function onSkinTemplateNavigation__Universal($sktemplate, &$links): void {
 		global $wgWikvenViewSourceUrl;
 		$title = $sktemplate->getTitle();
-		if (!$wgWikvenViewSourceUrl || !$title || !$title->canExist()) {
+		// A generated page (e.g. Version) has no source file, so its source link
+		// would 404 in the repository; skip it as if the URL were unconfigured.
+		if (!$wgWikvenViewSourceUrl || !$title || !$title->canExist()
+			|| !SourceFile::exists($title->getPrefixedText())
+		) {
 			return;
 		}
 		$links['views']['wikven-viewsource'] = [

--- a/includes/SourceFile.php
+++ b/includes/SourceFile.php
@@ -78,6 +78,20 @@ class SourceFile {
 	}
 
 	/**
+	 * Whether the page with the given prefixed title text was imported from a
+	 * source file, as opposed to generated during the build (like the Version
+	 * page). The edit/history/view-source links point at that source file, so
+	 * there is nothing for them to point at when it does not exist.
+	 */
+	public static function exists(string $titleText): bool {
+		global $wgWikvenSourceDirectory;
+		if ((string)$wgWikvenSourceDirectory === '') {
+			return false;
+		}
+		return is_file(rtrim($wgWikvenSourceDirectory, '/') . '/' . self::titleToFilename($titleText));
+	}
+
+	/**
 	 * Whether MediaWiki resolves a non-wikitext default content model for the
 	 * given title text — i.e. the title (via its extension or namespace) already
 	 * determines the content, so no ".wikitext" marker is needed. Driven by the

--- a/tests/phpunit/integration/SourceFileTest.php
+++ b/tests/phpunit/integration/SourceFileTest.php
@@ -52,4 +52,18 @@ class SourceFileTest extends MediaWikiIntegrationTestCase {
 			'dotted title that is not a content model' => ['wikven.yaml.wikitext']
 		];
 	}
+
+	/**
+	 * exists() reports whether a page was imported from a source file (so the
+	 * edit/history/view-source links have something to point at) rather than
+	 * generated during the build, like the Version page.
+	 */
+	public function testExists() {
+		$dir = $this->getNewTempDirectory();
+		file_put_contents($dir . '/Getting Started.wikitext', '');
+		$this->overrideConfigValue('WikvenSourceDirectory', $dir);
+
+		$this->assertTrue(SourceFile::exists('Getting Started'), 'imported page');
+		$this->assertFalse(SourceFile::exists('Version'), 'generated page');
+	}
 }


### PR DESCRIPTION
## Problem

On a generated page like [Version](https://chaotic-ground.github.io/wikven/Version.html), the **Edit** and **View History** buttons navigate to a GitHub **404**. The page is produced during the build, so there is no `docs/Version.wikitext` source file for those links to point at, yet `onGetLocalURL` still rewrites them to `$wgWikvenEditUrl` / `$wgWikvenHistoryUrl` (and `Main` adds a **View source** tab) as if a source existed.

## Fix

Add `SourceFile::exists()` (is the page's source file present on disk?) and gate the edit / history / view-source affordances on it:

- `Hider::onSkinTemplateNavigation__Universal` now drops the `edit`, `ve-edit`, `viewsource` and `history` tabs on a source-less page (in addition to the existing "URL not configured" case).
- `Main::onSkinTemplateNavigation__Universal` skips adding the **View source** tab when no source file exists.

A page with nothing behind it simply shows no edit/history/source affordance, instead of a link that 404s.

## Test

`SourceFileTest::testExists()` (integration, since `exists()` resolves content models via `MediaWikiServices`) asserts an imported page reports `true` and a generated one (`Version`) reports `false`.

Locally: `php -l` clean on all changed files, `composer phpcs` 20/20, `minus-x` all good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)