### PR TITLE
chore(repo): merge PRs by squash to stop release-please duplicates

### DIFF
--- a/.tf/repository.tf
+++ b/.tf/repository.tf
@@ -4,9 +4,9 @@ import {
 }
 resource "github_repository" "this" {
   allow_auto_merge            = true
-  allow_merge_commit          = true
+  allow_merge_commit          = false
   allow_rebase_merge          = false
-  allow_squash_merge          = false
+  allow_squash_merge          = true
   allow_update_branch         = true
   archived                    = false
   archive_on_destroy          = true
@@ -22,6 +22,8 @@ resource "github_repository" "this" {
   merge_commit_message        = "PR_BODY"
   merge_commit_title          = "PR_TITLE"
   name                        = "wikven"
+  squash_merge_commit_message = "PR_BODY"
+  squash_merge_commit_title   = "PR_TITLE"
   topics                      = ["docker-image", "mediawiki", "static-site-generator", "wikitext"]
   visibility                  = "public"
   vulnerability_alerts        = var.github_actions ? null : true


### PR DESCRIPTION
## Problem

The release PR (#30) lists most features **twice** in the changelog, e.g.:

```
* add a "View source" tab ... ([0178405])
* add a "View source" tab ... ([#119]) ([24e4d16])
```

### Root cause

`.tf/repository.tf` allows **merge-commit merging only** and sets `merge_commit_title = "PR_TITLE"`. So merging PR #119 leaves two conventional commits on `main`:

| commit | parents | subject |
|---|---|---|
| `0178405` (branch) | 1 | `feat: add a "View source" tab` |
| `24e4d16` (merge) | 2 | `feat: add a "View source" tab (#119)` |

Because it is a merge (not a squash), the branch commit survives, and the merge commit's title is itself a conventional commit. release-please counts both → duplicate entries. Commits that landed without a merge commit (single parent) appear once, which is why only some entries are doubled.

## Fix

Switch the repo to **squash-only** merging:

```hcl
allow_merge_commit          = false
allow_squash_merge          = true
squash_merge_commit_title   = "PR_TITLE"
squash_merge_commit_message = "PR_BODY"
```

One commit per PR (`feat: x (#NN)`), no leftover branch commit, so each feature is counted once and keeps its `(#NN)` PR link. This is release-please's intended workflow.

`merge_commit_*` lines are kept (GitHub retains them even while merge commits are disabled) to avoid plan drift.

## Note on the existing #30

This stops *future* duplicates. The 1.0.0 changelog already has the doubled history baked in; that PR is cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)