### PR TITLE
fix: abort the build when a page fails to import

### DIFF
--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -187,7 +187,12 @@ class Build extends Maintenance {
 		foreach ($options as $name => $value) {
 			$child->setOption($name, $value);
 		}
-		$child->execute();
+		// A child that returns false reports failure (e.g. ImportWikitext could
+		// not import every page); abort rather than publish a site missing
+		// content with a success exit code. Steps that return null are unaffected.
+		if ($child->execute() === false) {
+			$this->fatalError("Wikven: $class reported failures; aborting the build.");
+		}
 	}
 
 	/**

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -33,11 +33,12 @@ class ImportWikitext extends Maintenance {
 		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
 		RequestContext::getMain()->setUser($user);
 
-		$ok = true;
+		$failed = [];
 		foreach ($this->wikitextFiles($sourceDirectory) as $filename) {
 			$title = Title::newFromText($this->filenameToTitle($filename, $sourceDirectory));
 			if (!$title) {
 				$this->output('Invalid title: ' . basename($filename) . "\n");
+				$failed[] = basename($filename);
 				continue;
 			}
 
@@ -89,11 +90,21 @@ class ImportWikitext extends Maintenance {
 				$this->output(" done\n");
 			} else {
 				$this->output(" failed\n");
-				$ok = false;
+				$failed[] = $relative;
 			}
 		}
 
-		return $ok;
+		if ($failed) {
+			// Report to stderr and signal failure so the caller (build.php's
+			// step()) aborts: a static export that silently drops pages is worse
+			// than no export, and exits 0 either way without this.
+			$this->error(
+				'Failed to import ' . count($failed) . " page(s):\n  " . implode("\n  ", $failed)
+			);
+			return false;
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Problem

`ImportWikitext::execute()` tracked per-file success but `build.php`'s `step()` threw the return value away, so a build that dropped pages still printed `wikven: done` and **exited 0**.

```php
// maintenance/build.php (before)
private function step(string $class, string $file, array $options = []): void {
    $child = $this->createChild($class, $file);
    foreach ($options as $name => $value) { $child->setOption($name, $value); }
    $child->execute(); // return value discarded
}
```

Two ways a page is silently dropped: a failed `importOldRevision()`, or a file whose name maps to an invalid title (the `Invalid title:` branch `continue`d without flagging failure). Only `assertMainPageExists()` guarded a single page; any other missing article went unnoticed.

For a static-site generator the baked site **is** the product, so publishing a silently incomplete site with a success exit code is the worst failure mode, and it contradicts the loud-failure idiom used elsewhere (`fetchExtensions.php` `fatalError()`s on sub-command failures).

## Fix

- `ImportWikitext::execute()` collects the failed files (both invalid-title and failed-import), reports them to **stderr**, and returns `false`.
- `build.php`'s `step()` calls `fatalError()` when a child returns `false`, aborting the build. Steps that return `null` (every other step) are unaffected, since the check is strict `=== false`.

## Test

`php -l`, `mago --check`, `composer phpcs`, `minus-x` all clean. An end-to-end build smoke test that would exercise this path is tracked separately in #133.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)