### PR TITLE
test: add a build smoke test and AssetLocalizer coverage

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -42,9 +42,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Build with the shared GHA layer cache (same scope as docker-build.yaml)
+      # and load the image locally so the bake step below can run it.
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          load: true
+          tags: wikven
+          cache-from: type=gha,scope=wikven-image
+          cache-to: type=gha,mode=max,scope=wikven-image
+
       - name: Bake the docs site
         run: |
-          docker build -t wikven .
           mkdir -p dist
           docker run --rm \
             -v "$(pwd)/docs:/workspace/src" \

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -1,0 +1,69 @@
+name: Smoke test
+
+# Bake the docs source with the real image and assert the output is a complete,
+# self-contained site. The unit suite covers only helper classes, so without
+# this a regression anywhere in the bake pipeline (maintenance/, AssetLocalizer,
+# hooks, Dockerfile) would produce a broken site yet pass every other gate.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'run'
+      - 'WikvenSettings.php'
+      - 'extension.json'
+      - 'includes/**'
+      - 'maintenance/**'
+      - 'resources/**'
+      - 'i18n/**'
+      - 'docs/**'
+      - '.github/workflows/smoke.yaml'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'run'
+      - 'WikvenSettings.php'
+      - 'extension.json'
+      - 'includes/**'
+      - 'maintenance/**'
+      - 'resources/**'
+      - 'i18n/**'
+      - 'docs/**'
+      - '.github/workflows/smoke.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Bake the docs site
+        run: |
+          docker build -t wikven .
+          mkdir -p dist
+          docker run --rm \
+            -v "$(pwd)/docs:/workspace/src" \
+            -v "$(pwd)/dist:/workspace/dist" \
+            wikven
+
+      - name: Assert the bake produced a complete, self-contained site
+        run: |
+          set -euo pipefail
+          # The main page must land at the dist root (the build aborts on a
+          # failed import, so reaching here already means exit 0).
+          test -s dist/index.html
+
+          # Dumped CSS must not reference load.php: that endpoint only exists in
+          # a live MediaWiki, so a leftover is an AssetLocalizer regression that
+          # leaves the static site fetching styles from a server that is not there.
+          if grep -rIl --include='*.css' 'load\.php' dist; then
+            echo "::error::dumped CSS still references load.php (AssetLocalizer regression)"
+            exit 1
+          fi
+
+          echo "Smoke checks passed."

--- a/tests/phpunit/integration/AssetLocalizerTest.php
+++ b/tests/phpunit/integration/AssetLocalizerTest.php
@@ -14,7 +14,7 @@ class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
 	 * regex-fragile part of the static export: if they stop matching, the output
 	 * silently points at paths that only exist inside a live MediaWiki. Assert
 	 * that every reference form the build emits is rewritten to a local copy,
-	 * that look-alikes which must NOT match are left untouched, and that the
+	 * that look-alike paths which must NOT match are left untouched, and that the
 	 * referenced bytes are actually copied out.
 	 */
 	public function testLocalizeImagesRewritesDirectAssetPaths() {

--- a/tests/phpunit/integration/AssetLocalizerTest.php
+++ b/tests/phpunit/integration/AssetLocalizerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\AssetLocalizer;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\AssetLocalizer
+ */
+class AssetLocalizerTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * Direct skin/resource/extension asset url()s in dumped CSS are the most
+	 * regex-fragile part of the static export: if they stop matching, the output
+	 * silently points at paths that only exist inside a live MediaWiki. Assert
+	 * that every reference form the build emits is rewritten to a local copy,
+	 * that look-alikes which must NOT match are left untouched, and that the
+	 * referenced bytes are actually copied out.
+	 */
+	public function testLocalizeImagesRewritesDirectAssetPaths() {
+		$mwRoot = $this->getNewTempDirectory();
+		mkdir("$mwRoot/skins/Vector/images", 0777, true);
+		file_put_contents("$mwRoot/skins/Vector/images/arrow.svg", '<svg>arrow</svg>');
+		// AssetLocalizer reads the install root from $GLOBALS['IP'].
+		$this->setMwGlobals('IP', $mwRoot);
+
+		$dir = $this->getNewTempDirectory();
+		$css = "$dir/styles.css";
+		file_put_contents($css, implode("\n", [
+			// Plain, the JSON-escaped form combined-mode JS bundles use, and a
+			// cache-busting query: all reference the same asset and must rewrite.
+			'.a{background:url(/skins/Vector/images/arrow.svg)}',
+			'.b{background:url(\/skins/Vector/images/arrow.svg)}',
+			'.c{background:url(/skins/Vector/images/arrow.svg?a1b2)}',
+			// A non-image under skins/ and a path outside the rewritten roots: kept.
+			'.d{background:url(/skins/Vector/skin.css)}',
+			'.e{background:url(/static/logo.svg)}'
+		])
+			. "\n");
+
+		$rl = $this->getServiceContainer()->getResourceLoader();
+		AssetLocalizer::localizeImages($rl, $dir, [$css], 'en', 'vector');
+
+		$out = file_get_contents($css);
+		$this->assertStringNotContainsString('/skins/Vector/images/arrow.svg', $out, 'all three forms rewritten');
+		$this->assertSame(3, preg_match_all('~url\(\./img-[0-9a-f]{12}\.svg\)~', $out), 'rewritten to local copies');
+		$this->assertStringContainsString('url(/skins/Vector/skin.css)', $out, 'non-image left untouched');
+		$this->assertStringContainsString(
+			'url(/static/logo.svg)',
+			$out,
+			'path outside skins/resources/extensions left untouched'
+		);
+
+		// The three references share one decoded path, so one copy is dumped.
+		$copies = glob("$dir/img-*.svg");
+		$this->assertCount(1, $copies, 'deduplicated to a single dumped copy');
+		$this->assertSame('<svg>arrow</svg>', file_get_contents($copies[0]), 'asset bytes copied verbatim');
+	}
+}


### PR DESCRIPTION
## Problem

Test coverage was limited to pure helper classes (`SourceFile`, `SiteConfig`). Nothing exercised the code that actually bakes the site (`maintenance/*`, `AssetLocalizer`, the hooks), and no CI job ran a real build, so a regression anywhere in the bake pipeline would produce a broken static site and still pass every gate.

## Changes

**`smoke.yaml`** — a Smoke test workflow that bakes the `docs/` source with the real image (the same `docker build` + `docker run` the docs deploy uses, so it is proven in CI) and asserts the output is a complete, self-contained site:

- `dist/index.html` exists and is non-empty (main page at the dist root; combined with #146, reaching the assertions means the import did not silently drop pages).
- No dumped CSS still references `load.php` (that endpoint only exists in a live MediaWiki, so a leftover is an `AssetLocalizer` regression).

Verified against the live deployed site: `index.html` is 200 at the root and every dumped `*.css` has zero `load.php` references, so the assertions hold for a correct build. It runs on the build-relevant paths only.

**`AssetLocalizerTest.php`** — an integration test for the most regex-fragile component, covering every direct asset-path `url()` form the build emits (plain, the JSON-escaped form combined-mode JS bundles use, and a cache-busting query), the look-alikes that must **not** match (a non-image under `skins/`, a path outside the rewritten roots), and that the referenced bytes are copied out and deduplicated.

## Note

The `upload.wikimedia.org` hotlink invariant is intentionally not asserted: a failed Commons fetch (network) would make it flaky, and #145 will turn that failure into a hard build error, so the smoke build itself catches it at the source.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)