### PR TITLE
feat: ship a composite action and dogfood it in the docs deploy

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -40,13 +40,24 @@ jobs:
         with:
           enablement: true
 
-      - name: Build
-        run: |
-          docker build -t wikven .
-          docker run --rm \
-            -v "$(pwd)/docs:/workspace/src" \
-            -v "$(pwd)/dist:/workspace/dist" \
-            wikven
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # Build this commit's image (shared GHA layer cache) and load it locally.
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          load: true
+          tags: wikven
+          cache-from: type=gha,scope=wikven-image
+          cache-to: type=gha,mode=max,scope=wikven-image
+
+      # Dogfood the published composite action to bake the docs source.
+      - name: Bake the docs site
+        uses: ./action
+        with:
+          source: docs
+          output: dist
+          image: wikven
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 Read more on <https://chaotic-ground.github.io/wikven/>.
 
+## Use in a GitHub workflow
+
+Bake a wiki source tree into a static site with the composite action:
+
+```yaml
+- uses: chaotic-ground/wikven/action@v1
+  with:
+    source: docs   # directory of source files (default: src)
+    output: dist   # where the static site is written (default: dist)
+```
+
+It runs the published Docker image; pin a release tag (e.g. `ghcr.io/chaotic-ground/wikven:1.0.0`) via the `image` input for reproducible builds.
+
 [![Lint](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml/badge.svg)](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml)
 [![codecov](https://codecov.io/gh/chaotic-ground/wikven/graph/badge.svg)](https://codecov.io/gh/chaotic-ground/wikven)
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,0 +1,33 @@
+name: Bake a wiki with wikven
+description: Bake a MediaWiki source tree into a static site with wikven.
+branding:
+  icon: book-open
+  color: blue
+
+inputs:
+  source:
+    description: Directory holding the wiki source files to bake.
+    default: src
+  output:
+    description: Directory the static site is written to.
+    default: dist
+  image:
+    description: >-
+      The wikven image to run. Defaults to the rolling latest; pin a release
+      (e.g. ghcr.io/chaotic-ground/wikven:1.0.0) for reproducible builds.
+    default: ghcr.io/chaotic-ground/wikven:latest
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        SOURCE: ${{ inputs.source }}
+        OUTPUT: ${{ inputs.output }}
+        IMAGE: ${{ inputs.image }}
+      run: |
+        mkdir -p "$OUTPUT"
+        docker run --rm \
+          -v "$PWD/$SOURCE:/workspace/src" \
+          -v "$PWD/$OUTPUT:/workspace/dist" \
+          "$IMAGE"


### PR DESCRIPTION
## What

Adds `action/action.yml`, a **composite action** so consumers can bake a wiki in their own workflow without hand-writing `docker run`:

```yaml
- uses: chaotic-ground/wikven/action@v1
  with:
    source: docs   # default: src
    output: dist   # default: dist
```

It runs the wikven image (default `:latest`, pinnable via the `image` input) with the `/workspace/src` + `/workspace/dist` mounts, the same contract the docs deploy used inline.

## Dogfooding

`deploy-docs.yaml` now builds this commit's image with the shared `type=gha` layer cache and bakes through `./action`, so every docs deploy exercises the action (and the deploy build is no longer cold). The action's run/mount logic is the part under test; the deploy still builds from current source (passing `image: wikven`) rather than pulling a published image, so unreleased changes on `main` are reflected.

## Notes

- The default `image` is `:latest` (always present); the README and the action description point at pinning a release tag for reproducibility. The major-version tags this relies on come from the versioned-image work (#134).
- `actionlint` clean, `zizmor` no findings. Shell inputs are passed via `env:` (injection-safe).

Closes #149
Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)