### PR TITLE
ci: cache the release binary's embedding-image build

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -32,9 +32,21 @@ jobs:
 
       # The standalone binary embeds the same MediaWiki + Wikven tree the image
       # ships, so build that image first, then embed it into a FrankenPHP binary.
-      - name: Build the embedding image
-        run: docker build -t wikven .
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
+      # Build and load the embedding image with a per-architecture GHA layer
+      # cache, so repeated (e.g. nightly) builds reuse the base + apt layers.
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          load: true
+          tags: wikven
+          cache-from: type=gha,scope=wikven-image-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=wikven-image-${{ matrix.arch }}
+
+      # Classic build: it reads the loaded `wikven` image via FROM and exports
+      # the compiled binary (-o type=local); the static PHP compile that
+      # dominates here re-runs whenever the source changes regardless.
       - name: Build the standalone binary
         run: docker build -f Dockerfile.binary --target export -o type=local,dest=out .
 


### PR DESCRIPTION
## Problem

`build-binary.yaml` (release + nightly) built the embedding image with a cold `docker build -t wikven .` on every run, re-pulling the `mediawiki:1.45` base and re-running apt each time, on both the x86_64 and aarch64 matrix legs.

## Fix

Build and load the embedding image via buildx + `build-push-action` with a per-architecture `type=gha` layer cache (`scope=wikven-image-<arch>`), so repeated builds reuse the base + apt layers. The classic `Dockerfile.binary` build is unchanged: it still reads the loaded `wikven` image via `FROM wikven` and exports the binary with `-o type=local`.

The static PHP compile (`build-static.sh`) that dominates this job is intentionally left uncached: it re-runs whenever the source changes, so layer-caching it would not help.

This completes Docker-layer caching across all four image-building workflows (`docker-build`, `smoke`, `deploy-docs`, `build-binary`).

`actionlint` clean, `zizmor` no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)