### PR TITLE
docs: add an Installation page covering all three install methods

### DIFF
--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -1,6 +1,6 @@
 __TOC__
 
-Besides the [[Getting Started|Docker image]], {{wikven}} ships as a single self-contained executable that embeds MediaWiki, so you can build a site without Docker. It is available for Linux on x86_64 and arm64.
+Besides the [[Installation#Docker|Docker image]], {{wikven}} ships as a single self-contained executable that embeds MediaWiki, so you can build a site without Docker. It is available for Linux on x86_64 and arm64.
 
 == Download ==
 
@@ -63,5 +63,5 @@ The binary renders on its own, but uses these host programs when they are presen
 
 {{note|Fetching over HTTPS, Wikimedia Commons images via InstantCommons and any [[wikven.yaml#WikvenRepositories|third-party extensions or skins]], relies on your system's CA certificates. On a minimal system without them, install your distribution's CA bundle (for example the <code>ca-certificates</code> package). A site with only local content and images needs no network access.}}
 
-{{prevnext|Getting Started|Editing sidebar}}
+{{prevnext|Installation|Editing sidebar}}
 {{DISPLAYTITLE:Standalone binary}}

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -1,10 +1,10 @@
 On this page, we build a basic [[mw:en:"Hello, World!" program|Hello World]] page with {{wikven}}.
-{{note|This page assumes a unix-like OS.}}
+{{note|This page assumes a unix-like shell. The standalone binary is Linux-only; on macOS or Windows, use the Docker image.}}
 
-{{wikven}} builds a static website from a directory of wikitext. You can run it two ways: as a Docker image, or as a standalone [[Binary|binary]] that needs no Docker. This guide shows both, pick whichever you prefer.
+{{wikven}} builds a static website from a directory of wikitext. There are three ways to install it: the standalone [[Installation#Binary|binary]], the [[Installation#Docker|Docker image]], or [[Installation#Build from source|built from source]]. This guide uses the binary or Docker, pick whichever you have.
 
 ; Requirement
-:* either [https://www.docker.com/ Docker], or the standalone [[Binary|binary]] for your platform.
+:* the standalone [[Installation#Binary|binary]] (Linux), or [https://www.docker.com/ Docker] (any platform). See [[Installation]] to get either.
 
 ----
 
@@ -18,6 +18,11 @@ echo 'Hello, World!' > src/index.wikitext
 Then build the site. The rendered pages are written to <code>dist/</code>. Pick the tab for how you run {{wikven}}:
 
 <tabber>
+|-|Binary=
+Run it in the directory that holds <code>src/</code> (see [[Installation#Binary|Installation]] to get it):
+<syntaxhighlight lang="shell">
+./wikven build
+</syntaxhighlight>
 |-|Docker=
 Mount the source and output directories into the container:
 <syntaxhighlight lang="shell">
@@ -27,11 +32,6 @@ docker run --rm \
   ghcr.io/chaotic-ground/wikven
 </syntaxhighlight>
 The untagged image tracks the latest build; append a release tag such as <code>:1.0.0</code> to pin a specific version.
-|-|Binary=
-Run it in the directory that holds <code>src/</code> (see [[Binary]] to download it):
-<syntaxhighlight lang="shell">
-./wikven build
-</syntaxhighlight>
 </tabber>
 
 Open <code>dist/index.html</code> in your browser.
@@ -49,4 +49,4 @@ EOF
 
 Build again with the same command as before, and the site is titled "My Site".
 
-{{prevnext|Binary}}
+{{prevnext|Installation}}

--- a/docs/Installation.wikitext
+++ b/docs/Installation.wikitext
@@ -1,0 +1,42 @@
+__TOC__
+
+{{wikven}} runs in three ways. On Linux the standalone binary is the simplest, a single file with no Docker. On macOS or Windows, use the Docker image. Build from source if you want to modify {{wikven}} or run an unreleased version.
+
+== Binary ==
+
+A single self-contained executable that embeds MediaWiki, for Linux on x86_64 and arm64. Download it and make it executable:
+
+<syntaxhighlight lang="shell">
+curl -L -o wikven https://github.com/chaotic-ground/wikven/releases/latest/download/wikven-linux-x86_64
+chmod +x wikven
+</syntaxhighlight>
+
+On arm64, use <code>wikven-linux-aarch64</code>. See [[Binary|Standalone binary]] for installing it onto your <code>PATH</code>, nightly builds, and the optional host tools it uses.
+
+== Docker ==
+
+Works on any platform with [https://www.docker.com/ Docker], so it is the option to use on macOS and Windows. The image is published to the GitHub Container Registry:
+
+<syntaxhighlight lang="shell">
+docker pull ghcr.io/chaotic-ground/wikven
+</syntaxhighlight>
+
+The untagged image tracks the latest build; append a release tag such as <code>:1.0.0</code> to pin a specific version.
+
+== Build from source ==
+
+To modify {{wikven}} or run an unreleased commit, clone the repository and build the image yourself:
+
+<syntaxhighlight lang="shell">
+git clone https://github.com/chaotic-ground/wikven.git
+cd wikven
+docker build -t wikven .
+</syntaxhighlight>
+
+This produces a local <code>wikven</code> image you run exactly like the published one. To build the standalone binary from source instead, see [https://github.com/chaotic-ground/wikven/blob/main/Dockerfile.binary <code>Dockerfile.binary</code>].
+
+----
+
+Once you have {{wikven}}, head to [[Getting Started]] to build your first site.
+
+{{prevnext|Getting Started|Binary}}

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -2,6 +2,7 @@
 ** mainpage|mainpage-description
 * Docs
 ** Getting Started|Getting Started
+** Installation|Installation
 ** Binary|Standalone binary
 ** Editing sidebar|Editing sidebar
 ** Images|Images

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -3,8 +3,9 @@ behind [https://www.wikipedia.org/ Wikipedia]. It turns a directory of wikitext
 into a plain HTML site you can host anywhere, with no server or database to run.
 This documentation site is itself built with {{wikven}}.
 
-Start with [[Getting Started]], which builds a site two ways: as a Docker image,
-or as a standalone [[Binary|binary]].
+Start with [[Getting Started]] to build your first site, or see [[Installation]]
+for the three ways to install {{wikven}}: the standalone [[Installation#Binary|binary]],
+the [[Installation#Docker|Docker image]], or [[Installation#Build from source|from source]].
 
 == Supported features ==
 


### PR DESCRIPTION
## Why

Installation was split across **Getting Started** (a Docker/Binary build tabber) and the **Binary** page, with:

- no mention of **building from source**,
- the binary listed *second* even though it's the simplest on Linux, and
- the Getting Started binary tab pointing at the Binary page, which comes *later* in the reading order (a newcomer has to jump forward to download, then come back).

## What

- **New `Installation` page** presenting the three ways to get wikven, ordered **Binary → Docker → Build from source**: binary first (simplest on Linux), Docker as the cross-platform option (macOS/Windows), and a new build-from-source section (clone + `docker build`).
- **Getting Started**: reordered the build tabber **binary-first**, points at `Installation` to obtain wikven, and now notes up front that the binary is Linux-only so macOS/Windows users use Docker.
- **index** and **Binary** updated to link the new page; reading-order spine is now `Wikven → Getting Started → Installation → Binary → …`.
- The detailed **Binary** page stays (PATH install, nightly, host tools), linked from the Installation binary section.

The smoke test builds this docs tree, so a broken import would fail CI.

This is the first of the docs improvements; a deploy/hosting page and a `.wikven.yaml` split are planned next (the newcomer review flagged the missing hosting page as the top gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)