### PR TITLE
docs: pin the action example to a full SHA, not @v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,21 @@ Read more on <https://chaotic-ground.github.io/wikven/>.
 
 ## Use in a GitHub workflow
 
-Bake a wiki source tree into a static site with the composite action:
+Bake a wiki source tree into a static site with the composite action. Pin it to a
+full commit SHA rather than a tag: a tag can be moved to point at altered code, a
+commit SHA cannot, so pinning it is a basic defense against a supply-chain attack.
 
 ```yaml
-- uses: chaotic-ground/wikven/action@v1
+- uses: chaotic-ground/wikven/action@19392b75d379de9e349ef2963c11ec5545c3e6ab  # v1.0.0
   with:
     source: docs   # directory of source files (default: src)
     output: dist   # where the static site is written (default: dist)
 ```
 
-It runs the published Docker image; pin a release tag (e.g. `ghcr.io/chaotic-ground/wikven:1.0.0`) via the `image` input for reproducible builds.
+Copy the SHA of the [release](https://github.com/chaotic-ground/wikven/releases) you
+want and record its version in the trailing comment. It runs the published Docker
+image; pin a release tag (e.g. `ghcr.io/chaotic-ground/wikven:1.0.0`) via the `image`
+input for reproducible builds.
 
 [![Lint](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml/badge.svg)](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml)
 [![codecov](https://codecov.io/gh/chaotic-ground/wikven/graph/badge.svg)](https://codecov.io/gh/chaotic-ground/wikven)


### PR DESCRIPTION
## Why

The README's composite-action example used `uses: chaotic-ground/wikven/action@v1`. A floating tag like `@v1` can be moved to point at altered code; a full commit SHA cannot. The repo already pins every third-party action to a full SHA (with a version comment), so the example readers copy should teach the same supply-chain-hardening habit rather than a movable-tag reference.

## Change

- Recommend SHA pinning, with a one-line reason, and show the example pinned to a full SHA with the version in the trailing comment (the repo's own convention).
- Tell readers to copy the SHA of the release they want.

Note: the example SHA points at the action's current commit on `main`; it should be bumped to the actual `v1.0.0` release commit when 1.0.0 is cut.

`rumdl` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)