### PR TITLE
docs: add Deploying and Troubleshooting pages and landing framing

### DIFF
--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -1,0 +1,54 @@
+__TOC__
+
+{{wikven}} writes a self-contained <code>dist/</code> directory of static files, with no server or database behind it. Host it anywhere that serves static files.
+
+== GitHub Pages ==
+
+This workflow rebuilds and publishes the site on every push. It bakes the source with the {{wikven}} [https://github.com/chaotic-ground/wikven/tree/main/action composite action], then uploads <code>dist/</code> to Pages. Actions are pinned to a full commit SHA, not a tag, so a moved tag cannot swap them under you:
+
+<syntaxhighlight lang="yaml">
+name: Deploy
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
+      - uses: chaotic-ground/wikven/action@19392b75d379de9e349ef2963c11ec5545c3e6ab  # v1.0.0
+        with:
+          source: src
+          output: dist
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: dist
+      - id: deploy
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+</syntaxhighlight>
+
+Enable Pages for the repository under '''Settings → Pages → Build and deployment → Source: GitHub Actions'''. This documentation site is published this way.
+
+== Any static host ==
+
+Because <code>dist/</code> is just files, you can serve it from any static host (Netlify, Cloudflare Pages, an object store like S3, or a plain web server). Build the site in your CI or locally, then point the host at the <code>dist/</code> directory, or upload its contents to the server's document root.
+
+== Preview locally ==
+
+Open <code>dist/index.html</code> directly, or serve the directory so links and assets resolve exactly as they will in production:
+
+<syntaxhighlight lang="shell">
+cd dist && python3 -m http.server
+</syntaxhighlight>
+
+Then browse to <code>http://localhost:8000</code>.
+
+{{prevnext|Searching|Troubleshooting}}

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -34,7 +34,7 @@ docker run --rm \
 The untagged image tracks the latest build; append a release tag such as <code>:1.0.0</code> to pin a specific version.
 </tabber>
 
-Open <code>dist/index.html</code> in your browser.
+Open <code>dist/index.html</code> in your browser. To publish it online, see [[Deploying]].
 
 == Setting the title of the site ==
 

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -9,8 +9,10 @@
 ** Skins|Skins
 ** JavaScript|JavaScript
 ** Searching|Searching
+** Deploying|Deploying
+** Troubleshooting|Troubleshooting
 * References
-** wikven.yaml|.wikven.yaml
+** wikven.yaml|Configuration
 ** Development|Development
 *
 ** helppage|help-mediawiki

--- a/docs/Searching.wikitext
+++ b/docs/Searching.wikitext
@@ -40,5 +40,5 @@ there and runs the query from the URL, and the search box's "search for pages
 containing…" action and its Enter key go to that page. This site uses a page
 titled <code>Search</code>.
 
-{{prevnext|JavaScript|wikven.yaml}}
+{{prevnext|JavaScript|Deploying}}
 {{DISPLAYTITLE:Searching}}

--- a/docs/Troubleshooting.wikitext
+++ b/docs/Troubleshooting.wikitext
@@ -1,0 +1,25 @@
+__TOC__
+
+Common problems and what to check.
+
+== Thumbnails look low quality ==
+
+The [[Binary|standalone binary]] falls back to the built-in GD library, which produces lower-quality thumbnails and supports fewer formats. Install '''ImageMagick''' and '''librsvg''' on the build host for better output, or use the Docker image, which bundles them. See [[Images]].
+
+== The search box does nothing ==
+
+Search is client-side, provided by the SifterSearch extension. If the box does not respond, the site was built without it: add SifterSearch to your [[wikven.yaml|.wikven.yaml]] and rebuild. See [[Searching]].
+
+== A page is missing from the site ==
+
+The build aborts if any page fails to import, printing <code>Failed to import N page(s)</code> with the file names. A common cause is a file whose name does not map to a valid title; rename it (the build warns when a name does not round-trip). Re-run the build and read the log for the failing file.
+
+== Fetching fails over HTTPS ==
+
+Fetching Wikimedia Commons images and [[wikven.yaml#WikvenRepositories|third-party extensions or skins]] needs your system's CA certificates. On a minimal host without them (common with the standalone binary), install your distribution's CA bundle, for example the <code>ca-certificates</code> package. A site with only local content and images needs no network access.
+
+== The binary will not run on macOS or Windows ==
+
+The standalone binary is Linux-only (x86_64 and arm64). On macOS or Windows, use the Docker image instead. See [[Installation]].
+
+{{prevnext|Deploying|wikven.yaml}}

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -3,6 +3,13 @@ behind [https://www.wikipedia.org/ Wikipedia]. It turns a directory of wikitext
 into a plain HTML site you can host anywhere, with no server or database to run.
 This documentation site is itself built with {{wikven}}.
 
+Reach for {{wikven}} when your content is already MediaWiki wikitext, or when you
+want MediaWiki's templates, parser functions, gadgets and extensions but a static
+result with nothing to run: a project's documentation site, an archived wiki
+you can browse as plain HTML, or a personal wiki. Unlike a general static-site generator
+such as Hugo or MkDocs, it renders real wikitext through MediaWiki itself, so it
+assumes you are comfortable with wikitext.
+
 Start with [[Getting Started]] to build your first site, or see [[Installation]]
 for the three ways to install {{wikven}}: the standalone [[Installation#Binary|binary]],
 the [[Installation#Docker|Docker image]], or [[Installation#Build from source|from source]].

--- a/docs/wikven.yaml.wikitext
+++ b/docs/wikven.yaml.wikitext
@@ -95,4 +95,4 @@ docker run --rm --entrypoint cat ghcr.io/chaotic-ground/wikven extensions/Wikven
 
 It is also in the [https://github.com/chaotic-ground/wikven/blob/main/default.yaml repository].
 
-{{prevnext|Searching|Development}}
+{{prevnext|Troubleshooting|Development}}


### PR DESCRIPTION
Closes the gaps the newcomer review flagged after the Installation page (#152).

## Changes

- **Deploying** (new): the "host anywhere" promise had no follow-through. Adds a copy-pasteable **GitHub Pages** workflow (actions pinned to full SHAs, baking via the composite action), guidance for **any static host**, and a **local preview** snippet. Linked from the end of Getting Started.
- **Troubleshooting** (new): a FAQ for the common snags, thumbnail quality, a dead search box, a missing page, CA certificates, and the Linux-only binary.
- **index**: a short *why / who it's for* paragraph (use cases + a one-line contrast with general SSGs) so a reader can self-select.
- **Sidebar**: relabel the `.wikven.yaml` entry **Configuration** for discoverability.

Both new pages are wired into the sidebar and the prev/next reading spine (`… Searching → Deploying → Troubleshooting → Configuration → Development`).

The smoke test builds this docs tree, so a broken import fails CI.

Deferred (bigger, optional): splitting `WikvenRepositories` out of the Configuration page into its own page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)