### PR TITLE
feat: add a serve subcommand for local preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ COPY ./ /var/www/html/extensions/Wikven
 COPY WikvenSettings.php /var/www/html/
 
 COPY run /usr/local/bin/
-CMD ["/usr/local/bin/run"]
+# The entry point is wikven's run script; the command is the subcommand it
+# dispatches on (default "build"), so `docker run ... <image> serve` previews.
+ENTRYPOINT ["/usr/local/bin/run"]
+CMD ["build"]

--- a/caddy/wikven.go
+++ b/caddy/wikven.go
@@ -1,12 +1,15 @@
-// Package wikvencaddy registers a "build" subcommand on the wikven binary, so
-// the static site can be built with `./wikven build` instead of the longer
-// `./wikven php-cli build.php`. It simply re-invokes the binary's embedded
-// build.php through php-cli.
+// Package wikvencaddy registers "build" and "serve" subcommands on the wikven
+// binary, so the static site can be built with `./wikven build` and previewed
+// with `./wikven serve` instead of the longer underlying invocations. Both
+// re-invoke this same binary: build through the embedded php-cli, serve through
+// Caddy's built-in file-server.
 package wikvencaddy
 
 import (
+	"flag"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	caddycmd "github.com/caddyserver/caddy/v2/cmd"
 )
@@ -19,19 +22,45 @@ func init() {
 		Long: "Builds WIKVEN_WORKDIR/src into WIKVEN_WORKDIR/dist " +
 			"(WIKVEN_WORKDIR defaults to the current directory).",
 		Func: func(_ caddycmd.Flags) (int, error) {
-			self, err := os.Executable()
-			if err != nil {
-				return 1, err
-			}
-			cmd := exec.Command(self, "php-cli", "build.php")
-			cmd.Stdin = os.Stdin
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			cmd.Env = os.Environ()
-			if err := cmd.Run(); err != nil {
-				return 1, err
-			}
-			return 0, nil
+			return reexec("php-cli", "build.php")
 		},
 	})
+
+	serveFlags := flag.NewFlagSet("serve", flag.ExitOnError)
+	serveFlags.String("listen", ":8080", "the address to listen on")
+	caddycmd.RegisterCommand(caddycmd.Command{
+		Name:  "serve",
+		Usage: "[--listen <addr>]",
+		Short: "Serve the built static site for local preview",
+		Long: "Serves WIKVEN_WORKDIR/dist (WIKVEN_WORKDIR defaults to the current " +
+			"directory) over HTTP, on :8080 by default, for local preview.",
+		Flags: serveFlags,
+		Func: func(fl caddycmd.Flags) (int, error) {
+			workdir := os.Getenv("WIKVEN_WORKDIR")
+			if workdir == "" {
+				workdir = "."
+			}
+			return reexec("file-server",
+				"--root", filepath.Join(workdir, "dist"),
+				"--listen", fl.String("listen"))
+		},
+	})
+}
+
+// reexec runs this same binary with the given arguments, wiring through the
+// standard streams and the current environment.
+func reexec(args ...string) (int, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return 1, err
+	}
+	cmd := exec.Command(self, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		return 1, err
+	}
+	return 0, nil
 }

--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -46,7 +46,7 @@ echo 'Hello, World!' > src/index.wikitext
 wikven build
 </syntaxhighlight>
 
-The rendered site is written to <code>dist/</code>. The working directory defaults to the current directory; set <code>WIKVEN_WORKDIR</code> to build a project elsewhere:
+The rendered site is written to <code>dist/</code>. Preview it with <code>wikven serve</code> (see [[Deploying#Preview locally|Deploying]]). The working directory defaults to the current directory; set <code>WIKVEN_WORKDIR</code> to build a project elsewhere:
 
 <syntaxhighlight lang="shell">
 WIKVEN_WORKDIR=/path/to/project wikven build

--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -43,12 +43,22 @@ Because <code>dist/</code> is just files, you can serve it from any static host 
 
 == Preview locally ==
 
-Open <code>dist/index.html</code> directly, or serve the directory so links and assets resolve exactly as they will in production:
+Open <code>dist/index.html</code> directly, or serve the directory so links and assets resolve exactly as they will in production. {{wikven}} has a built-in <code>serve</code> command for this.
+
+With the [[Binary|standalone binary]], it serves <code>dist/</code> on <code>http://localhost:8080</code> (override with <code>--listen</code>):
 
 <syntaxhighlight lang="shell">
-cd dist && python3 -m http.server
+wikven serve
 </syntaxhighlight>
 
-Then browse to <code>http://localhost:8000</code>.
+With the Docker image, run the <code>serve</code> command and publish the port (the build output must already be in the mounted <code>dist/</code>):
+
+<syntaxhighlight lang="shell">
+docker run --rm -p 8080:8080 \
+  -v "$(pwd)/dist:/workspace/dist" \
+  ghcr.io/chaotic-ground/wikven serve
+</syntaxhighlight>
+
+Any static server works too, for example <code>cd dist && python3 -m http.server</code>.
 
 {{prevnext|Searching|Troubleshooting}}

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -34,7 +34,7 @@ docker run --rm \
 The untagged image tracks the latest build; append a release tag such as <code>:1.0.0</code> to pin a specific version.
 </tabber>
 
-Open <code>dist/index.html</code> in your browser. To publish it online, see [[Deploying]].
+Preview the site with <code>wikven serve</code>, then open <code>http://localhost:8080</code> (with Docker, see [[Deploying#Preview locally|Deploying]]). You can also open <code>dist/index.html</code> directly, though some links and assets resolve correctly only when served. To publish it online, see [[Deploying]].
 
 == Setting the title of the site ==
 

--- a/run
+++ b/run
@@ -6,6 +6,19 @@ set -euo pipefail; IFS=$'\n\t'
 # it so the PHP maintenance children (which read it via getenv) see any override.
 export WIKVEN_WORKDIR="${WIKVEN_WORKDIR:-/workspace}"
 
+# The image's entry point is this script; the first argument selects the
+# command (default "build"), mirroring the standalone binary's subcommands.
+command="${1:-build}"
+
+if [ "$command" = "serve" ]; then
+  # Serve the already-built site for local preview. The container always
+  # listens on 8080; map it to a host port with `docker run -p 8080:8080`.
+  exec php -S "0.0.0.0:8080" -t "$WIKVEN_WORKDIR/dist"
+elif [ "$command" != "build" ]; then
+  echo "wikven: unknown command '$command'; expected 'build' or 'serve'" >&2
+  exit 2
+fi
+
 cd /var/www/html
 
 php maintenance/run.php install \


### PR DESCRIPTION
## What

Building a site produced `dist/` but left previewing it to the reader. This adds a `serve` command that serves the built site over HTTP, mirroring `build`:

- **Standalone binary**: `wikven serve` serves `dist/` on `http://localhost:8080` (override with `--listen`), via Caddy's embedded file-server.
- **Docker image**: the entry point becomes the run script with the command as its argument, so `docker run --rm -p 8080:8080 -v "$(pwd)/dist:/workspace/dist" <image> serve` serves the mounted `dist/` (via PHP's built-in server). `docker run <image>` still builds (the default command `build`).

Documented under **Deploying → Preview locally**, with a pointer from the binary page.

## Validation

- `go build ./...` and `go vet ./...` pass on the caddy module (also CI-checked); `gofmt` clean.
- `bash -n run` clean.
- The smoke test exercises `docker run <image>` (build) through the new entry point.

## BREAKING CHANGE

The Docker image now has an `ENTRYPOINT` (the run script) and a default `CMD` of `build`. `docker run <image>` still builds, but a trailing argument is now a wikven subcommand (`build` or `serve`) rather than the container's command; use `--entrypoint` to run something else. This is intentional for the pre-1.0 image interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)