### PR TITLE
docs: add Pages and Why-wikitext pages, install-first ordering

### DIFF
--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -63,5 +63,5 @@ The binary renders on its own, but uses these host programs when they are presen
 
 {{note|Fetching over HTTPS, Wikimedia Commons images via InstantCommons and any [[wikven.yaml#WikvenRepositories|third-party extensions or skins]], relies on your system's CA certificates. On a minimal system without them, install your distribution's CA bundle (for example the <code>ca-certificates</code> package). A site with only local content and images needs no network access.}}
 
-{{prevnext|Installation|Editing sidebar}}
+{{prevnext|Pages|Editing sidebar}}
 {{DISPLAYTITLE:Standalone binary}}

--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -37,6 +37,8 @@ jobs:
 
 Enable Pages for the repository under '''Settings → Pages → Build and deployment → Source: GitHub Actions'''. This documentation site is published this way.
 
+{{note|A GitHub '''project''' page is served from a subdirectory (<code>username.github.io/repo/</code>). Page-to-page links keep working because {{wikven}} writes them relative, but anything that needs an absolute path, in particular [[Searching|search]], must be told that base path. A '''user/organization''' page (served at the domain root) needs no such setting.}}
+
 == Any static host ==
 
 Because <code>dist/</code> is just files, you can serve it from any static host (Netlify, Cloudflare Pages, an object store like S3, or a plain web server). Build the site in your CI or locally, then point the host at the <code>dist/</code> directory, or upload its contents to the server's document root.

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -49,4 +49,4 @@ EOF
 
 Build again with the same command as before, and the site is titled "My Site".
 
-{{prevnext|Installation}}
+{{prevnext|Installation|Pages}}

--- a/docs/Installation.wikitext
+++ b/docs/Installation.wikitext
@@ -39,4 +39,4 @@ This produces a local <code>wikven</code> image you run exactly like the publish
 
 Once you have {{wikven}}, head to [[Getting Started]] to build your first site.
 
-{{prevnext|Getting Started|Binary}}
+{{prevnext|Why wikitext|Getting Started}}

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -1,8 +1,10 @@
 * navigation
 ** mainpage|mainpage-description
 * Docs
-** Getting Started|Getting Started
+** Why wikitext|Why wikitext
 ** Installation|Installation
+** Getting Started|Getting Started
+** Pages|Pages
 ** Binary|Standalone binary
 ** Editing sidebar|Editing sidebar
 ** Images|Images

--- a/docs/Pages.wikitext
+++ b/docs/Pages.wikitext
@@ -1,0 +1,33 @@
+__TOC__
+
+Each file in your source directory becomes a page. {{wikven}} derives the page's title, and namespace, from the file's path, so the file name is how you choose them.
+
+== From file name to page ==
+
+A file ending in <code>.wikitext</code> becomes a wiki page whose title is the path with <code>.wikitext</code> removed, so <code>src/Help.wikitext</code> is the page "Help", served at <code>Help.html</code>.
+
+Titles are kept as written: spaces stay spaces (name the file <code>Getting Started.wikitext</code>, not with an underscore), and the first letter keeps its case. Name your entry page <code>index</code> so it builds to <code>index.html</code>, the file a static host serves at the site root.
+
+If a file name does not map cleanly to a title (MediaWiki would normalise it differently), the build warns, because the page's edit and history links are derived from the file name and would otherwise not resolve. Rename the file to a title that is already normalised.
+
+== Linking between pages ==
+
+Link with <code><nowiki>[[Title]]</nowiki></code>, or <code><nowiki>[[Title|label]]</nowiki></code>, the standard {{ml|Help:Links|wikitext link}}. {{wikven}} rewrites these to the matching <code>.html</code> paths in the static output, so internal links work with no server.
+
+== Subpages ==
+
+Put a file in a subdirectory to create a {{ml|Help:Subpages|subpage}}: <code>src/Guide/Setup.wikitext</code> becomes the page "Guide/Setup".
+
+== Namespaces ==
+
+Prefix the file name with a namespace to place the page there:
+
+* <code>Template:Infobox.wikitext</code> is the template "Template:Infobox" (see [[#Templates]]).
+* <code>File:Logo.png.wikitext</code> is the description page for an uploaded <code>Logo.png</code> (see [[Images]]).
+* <code>MediaWiki:Common.css</code> and <code>MediaWiki:Common.js</code> are the site-wide stylesheet and script (see [[JavaScript]]). These keep their extension and need no <code>.wikitext</code> marker, because the name already carries the content type.
+
+== Templates ==
+
+Put a <code>Template:Name.wikitext</code> file in your source and use it on any page as <code><nowiki>{{Name}}</nowiki></code>, with parameters and {{ml|Help:Parser functions|parser functions}} exactly as in MediaWiki. This site's pages transclude such templates, for example a <code>Template:wikven</code> that renders "{{wikven}}". The syntax itself is standard MediaWiki; see {{ml|Help:Templates}}.
+
+{{prevnext|Getting Started|Binary}}

--- a/docs/Why wikitext.wikitext
+++ b/docs/Why wikitext.wikitext
@@ -1,0 +1,23 @@
+__TOC__
+
+{{wikven}} authors content in {{ml|Wikitext}}, MediaWiki's markup, rather than Markdown. If you are coming from a Markdown-based site generator, here is what changes, and why you might want it.
+
+== What wikitext adds ==
+
+* '''{{ml|Help:Templates|Templates}}''' — reusable, parameterised snippets transcluded with <code><nowiki>{{...}}</nowiki></code>. Markdown has no equivalent; you copy and paste instead. See [[Pages#Templates]].
+* '''{{ml|Help:Parser functions|Parser functions}} and magic words''' — light logic and computed values (<code><nowiki>{{#if:}}</nowiki></code>, dates, page info) written in the page itself.
+* '''Structured linking''' — <code><nowiki>[[Page]]</nowiki></code> internal links, {{ml|Help:Categories|categories}} and redirects, managed by the wiki rather than by hand.
+* '''Rich media and references''' — image {{ml|Help:Images|thumbnails and galleries}} and footnotes in one consistent syntax.
+* '''An extension ecosystem''' — syntax highlighting, math and more, added as [[wikven.yaml|extensions]].
+
+== What Markdown does better ==
+
+* '''Simplicity''' — a smaller, more readable syntax with a gentler learning curve, especially for tables and templates.
+* '''Ubiquity''' — Markdown is supported almost everywhere and has a single standard, [https://commonmark.org/ CommonMark]; wikitext has several dialects and thinner editor and linting tooling.
+* '''Lightweight rendering''' — Markdown renders with a small library, whereas wikitext normally needs MediaWiki itself.
+
+== Where {{wikven}} fits ==
+
+That last cost, running MediaWiki, is the one {{wikven}} removes: it renders your wikitext through MediaWiki once, at build time, and ships plain static HTML. You get templates, parser functions and the rest with nothing to run in production. Reach for {{wikven}} when that trade is worth it, typically when your content is already wikitext, or when templates and transclusion would save real work.
+
+{{prevnext|Installation}}

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -8,18 +8,19 @@ want MediaWiki's templates, parser functions, gadgets and extensions but a stati
 result with nothing to run: a project's documentation site, an archived wiki
 you can browse as plain HTML, or a personal wiki. Unlike a general static-site generator
 such as Hugo or MkDocs, it renders real wikitext through MediaWiki itself, so it
-assumes you are comfortable with wikitext.
+assumes you are comfortable with wikitext (see [[Why wikitext]] for the trade-offs).
 
-Start with [[Getting Started]] to build your first site, or see [[Installation]]
-for the three ways to install {{wikven}}: the standalone [[Installation#Binary|binary]],
-the [[Installation#Docker|Docker image]], or [[Installation#Build from source|from source]].
+See [[Installation]] for the three ways to install {{wikven}}, the standalone
+[[Installation#Binary|binary]], the [[Installation#Docker|Docker image]], or
+[[Installation#Build from source|from source]], then [[Getting Started]] to build
+your first site.
 
 == Supported features ==
 
 With {{wikven}}, you can use the following features of MediaWiki.
 
-* {{ml|Wikitext}}
-* {{ml|Help:Templates|Templates}}
+* {{ml|Wikitext}} pages (see [[Pages]])
+* [[Pages#Templates|Templates]]
 * [[Images]] from Wikimedia Commons or local files
 * [[JavaScript]] (MediaWiki:Common.js and gadgets)
 * {{ml|Bundled extensions and skins}}
@@ -34,5 +35,5 @@ These need a live wiki, so they are not part of the static export:
 * All editors ({{ml|Extension:WikiEditor|WikiEditor}}, <!--
 -->{{ml|Extension:VisualEditor|VisualEditor}} and {{ml|Extension:CodeEditor|CodeEditor}})
 
-{{prevnext|Getting Started}}
+{{prevnext|Why wikitext}}
 {{DISPLAYTITLE:Wikven}}


### PR DESCRIPTION
Acts on the second newcomer review plus the wikitext-vs-Markdown question. Per the steer, anything mediawiki.org already documents is linked out rather than re-explained; these pages carry the wikven-specific parts.

## New pages

- **Pages** — the authoring rules a real multi-page wiki needs: how a file name maps to a title and to the output `.html`, names with spaces/case and the `index` root convention, subpages, internal links, and namespace prefixes (`Template:`, `File:`, `MediaWiki:`). This is the #1 gap the review flagged (a newcomer could only make a single Hello-World page). Templates are covered here (where to put `Template:Name.wikitext`, use as `{{Name}}`), with the syntax linked to mediawiki.org.
- **Why wikitext** — a concise wikitext-vs-Markdown comparison for the "should I use this" decision, framed around the fact that wikven's static bake removes wikitext's usual cost (running MediaWiki).

## Integration

- Landing links both; the **Templates** feature now points at `Pages#Templates` instead of off-site.
- Reading spine and sidebar reordered **Installation before Getting Started**, matching the prerequisite the Getting Started box already states.
- **Deploying** gains a note about base paths for GitHub project-page (subdirectory) deploys.

New spine: `Wikven → Why wikitext → Installation → Getting Started → Pages → Binary → …`.

The smoke test builds this docs tree, so a broken import fails CI.

Deferred to a follow-up: unifying the config page's name (Configuration vs wikven.yaml), which touches links across many pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)