### PR TITLE
docs: give the configuration page one name (Configuration)

### DIFF
--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -38,7 +38,7 @@ The commands below assume it is on your <code>PATH</code>. If you skipped this s
 
 == Building a site ==
 
-Put your wikitext and a [[wikven.yaml|.wikven.yaml]] in a <code>src/</code> directory, then build:
+Put your wikitext and a [[Configuration|.wikven.yaml]] in a <code>src/</code> directory, then build:
 
 <syntaxhighlight lang="shell">
 mkdir -p src
@@ -52,16 +52,16 @@ The rendered site is written to <code>dist/</code>. Preview it with <code>wikven
 WIKVEN_WORKDIR=/path/to/project wikven build
 </syntaxhighlight>
 
-The output is the same as the Docker image's: the binary embeds MediaWiki, the bundled extensions and skins, and every interface language, and it reads the same [[wikven.yaml|.wikven.yaml]] layered over {{wikven}}'s defaults.
+The output is the same as the Docker image's: the binary embeds MediaWiki, the bundled extensions and skins, and every interface language, and it reads the same [[Configuration|.wikven.yaml]] layered over {{wikven}}'s defaults.
 
 == Optional host tools ==
 
 The binary renders on its own, but uses these host programs when they are present:
 
 * '''ImageMagick''' and '''librsvg''' produce higher-quality thumbnails. Without them the binary uses the built-in GD library for raster images and serves SVG inline. See [[Images]].
-* '''git''' is needed only to fetch [[wikven.yaml#WikvenRepositories|third-party extensions and skins]].
+* '''git''' is needed only to fetch [[Configuration#WikvenRepositories|third-party extensions and skins]].
 
-{{note|Fetching over HTTPS, Wikimedia Commons images via InstantCommons and any [[wikven.yaml#WikvenRepositories|third-party extensions or skins]], relies on your system's CA certificates. On a minimal system without them, install your distribution's CA bundle (for example the <code>ca-certificates</code> package). A site with only local content and images needs no network access.}}
+{{note|Fetching over HTTPS, Wikimedia Commons images via InstantCommons and any [[Configuration#WikvenRepositories|third-party extensions or skins]], relies on your system's CA certificates. On a minimal system without them, install your distribution's CA bundle (for example the <code>ca-certificates</code> package). A site with only local content and images needs no network access.}}
 
 {{prevnext|Pages|Editing sidebar}}
 {{DISPLAYTITLE:Standalone binary}}

--- a/docs/Configuration.wikitext
+++ b/docs/Configuration.wikitext
@@ -1,6 +1,6 @@
 __TOC__
 
-The configuration file follows the same shape as {{ml|Manual:YAML settings file format|MediaWiki's own YAML settings format}}: a top-level <code>extensions</code> list, a <code>skins</code> list, and a <code>config</code> map.
+Configuration lives in a <code>.wikven.yaml</code> file in your source directory. It follows the same shape as {{ml|Manual:YAML settings file format|MediaWiki's own YAML settings format}}: a top-level <code>extensions</code> list, a <code>skins</code> list, and a <code>config</code> map.
 
 The file may also be written as <code>.wikven.json</code> with the same structure. When both files are present, <code>.wikven.yaml</code> takes precedence and <code>.wikven.json</code> is ignored (the build logs a warning).
 
@@ -17,8 +17,6 @@ config:
   WikvenEditUrl: https://github.com/yourname/some-repository/edit/branch-name/path/to/$1
   WikvenHistoryUrl: https://github.com/yourname/some-repository/commits/branch-name/path/to/$1
 </syntaxhighlight>
-{{DISPLAYTITLE:.wikven.yaml}}
-
 == <code>extensions</code> ==
 A list of extension names to load. {{ml|Bundled extensions|Bundled extensions}} work by name alone; a name that is not bundled is treated as third-party and fetched from a source you declare in [[#WikvenRepositories|<code>WikvenRepositories</code>]].
 

--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -65,7 +65,7 @@ The <code>run</code> script:
 
 == Configuration ==
 
-Configuration is layered. <code>default.yaml</code> ships {{wikven}}'s baseline MediaWiki settings; the site's [[wikven.yaml|.wikven.yaml]] is merged on top. <code>WikvenSettings.php</code> reads both with MediaWiki's own YAML settings parser, applies the merged <code>config</code> map, loads the listed <code>extensions</code> and <code>skins</code>, and points <code>$wgLogos</code> at the uploaded <code>WikvenLogos</code> files. It also detects the thumbnailing backend at run time, ImageMagick and rsvg when available, otherwise the built-in GD library plus native inline SVG, so the same build works in the image and in a binary that has only GD.
+Configuration is layered. <code>default.yaml</code> ships {{wikven}}'s baseline MediaWiki settings; the site's [[Configuration|.wikven.yaml]] is merged on top. <code>WikvenSettings.php</code> reads both with MediaWiki's own YAML settings parser, applies the merged <code>config</code> map, loads the listed <code>extensions</code> and <code>skins</code>, and points <code>$wgLogos</code> at the uploaded <code>WikvenLogos</code> files. It also detects the thumbnailing backend at run time, ImageMagick and rsvg when available, otherwise the built-in GD library plus native inline SVG, so the same build works in the image and in a binary that has only GD.
 
 == Why these steps exist ==
 
@@ -73,7 +73,7 @@ A live wiki relies on <code>load.php</code>, an action API, and a database; a st
 
 == Third-party extensions and skins ==
 
-Names in <code>extensions</code>/<code>skins</code> that are not bundled with {{wikven}} are fetched at build time by <code>maintenance/fetchExtensions.php</code>, from a source declared in [[wikven.yaml#WikvenRepositories|<code>WikvenRepositories</code>]] (a tarball, a Git repository, or a Composer package). This runs after install but before <code>WikvenSettings.php</code> is wired in, so the components are on disk by the time MediaWiki loads them.
+Names in <code>extensions</code>/<code>skins</code> that are not bundled with {{wikven}} are fetched at build time by <code>maintenance/fetchExtensions.php</code>, from a source declared in [[Configuration#WikvenRepositories|<code>WikvenRepositories</code>]] (a tarball, a Git repository, or a Composer package). This runs after install but before <code>WikvenSettings.php</code> is wired in, so the components are on disk by the time MediaWiki loads them.
 
 == Standalone binary ==
 

--- a/docs/Editing sidebar.wikitext
+++ b/docs/Editing sidebar.wikitext
@@ -9,7 +9,7 @@ Each top-level <code>*</code> line is a heading, and each <code>**</code> line b
 ** Getting Started|Getting Started
 ** Images|Images
 * References
-** wikven.yaml|.wikven.yaml
+** Configuration|.wikven.yaml
 </syntaxhighlight>
 
 == What is removed ==

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -38,7 +38,7 @@ Preview the site with <code>wikven serve</code>, then open <code>http://localhos
 
 == Setting the title of the site ==
 
-For configuration, create a [[wikven.yaml|<code>.wikven.yaml</code>]] file in your <code>src</code> directory.
+For configuration, create a [[Configuration|<code>.wikven.yaml</code>]] file in your <code>src</code> directory.
 
 <syntaxhighlight lang="shell">
 cat <<EOF > src/.wikven.yaml

--- a/docs/JavaScript.wikitext
+++ b/docs/JavaScript.wikitext
@@ -6,7 +6,7 @@ Site-wide JavaScript lives in <code>MediaWiki:Common.js</code>, just like on a r
 
 == Gadgets ==
 
-To use {{ml|Extension:Gadgets|gadgets}}, enable the bundled Gadgets extension in [[wikven.yaml|.wikven.yaml]]:
+To use {{ml|Extension:Gadgets|gadgets}}, enable the bundled Gadgets extension in [[Configuration|.wikven.yaml]]:
 
 <syntaxhighlight lang="yaml">
 extensions:

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -14,7 +14,7 @@
 ** Deploying|Deploying
 ** Troubleshooting|Troubleshooting
 * References
-** wikven.yaml|Configuration
+** Configuration|Configuration
 ** Development|Development
 *
 ** helppage|help-mediawiki

--- a/docs/Searching.wikitext
+++ b/docs/Searching.wikitext
@@ -6,7 +6,7 @@ SifterSearch indexes the rendered pages with [https://pagefind.app/ Pagefind] an
 
 == Enabling it ==
 
-SifterSearch is not bundled, so fetch it in [[wikven.yaml|.wikven.yaml]] and tell it where to write and serve the index:
+SifterSearch is not bundled, so fetch it in [[Configuration|.wikven.yaml]] and tell it where to write and serve the index:
 
 <syntaxhighlight lang="yaml">
 extensions:
@@ -29,7 +29,7 @@ config:
 
 <code>SifterSearchOutputDir</code> is a filesystem path inside the build output (the image writes the site to <code>/workspace/dist</code>); <code>SifterSearchBundlePath</code> is the URL it is served from. If your site lives in a subdirectory, include it: this site deploys under <code>/wikven</code> on GitHub Pages, so it uses <code>/wikven/pagefind/</code>.
 
-{{note|For a reproducible build, pin a released version and add its <code>sha256</code>, as with any tarball source. See [[wikven.yaml#WikvenRepositories|.wikven.yaml]] for the fetch options.}}
+{{note|For a reproducible build, pin a released version and add its <code>sha256</code>, as with any tarball source. See [[Configuration#WikvenRepositories|.wikven.yaml]] for the fetch options.}}
 
 == Full results page ==
 

--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -1,4 +1,4 @@
-You can choose {{ml|Bundled extensions and skins|bundled skins}} in [[wikven.yaml|.wikven.yaml]].
+You can choose {{ml|Bundled extensions and skins|bundled skins}} in [[Configuration|.wikven.yaml]].
 
 == Available skins ==
 
@@ -20,7 +20,7 @@ skins:
 
 == Third-party skins ==
 
-A skin that is not bundled can be listed in <code>skins</code> too, with its source declared in [[wikven.yaml#WikvenRepositories|<code>WikvenRepositories</code>]]. It is fetched at build time and may be the default like any other.
+A skin that is not bundled can be listed in <code>skins</code> too, with its source declared in [[Configuration#WikvenRepositories|<code>WikvenRepositories</code>]]. It is fetched at build time and may be the default like any other.
 
 <syntaxhighlight lang="yaml">
 skins:

--- a/docs/Troubleshooting.wikitext
+++ b/docs/Troubleshooting.wikitext
@@ -8,7 +8,7 @@ The [[Binary|standalone binary]] falls back to the built-in GD library, which pr
 
 == The search box does nothing ==
 
-Search is client-side, provided by the SifterSearch extension. If the box does not respond, the site was built without it: add SifterSearch to your [[wikven.yaml|.wikven.yaml]] and rebuild. See [[Searching]].
+Search is client-side, provided by the SifterSearch extension. If the box does not respond, the site was built without it: add SifterSearch to your [[Configuration|.wikven.yaml]] and rebuild. See [[Searching]].
 
 == A page is missing from the site ==
 
@@ -16,10 +16,10 @@ The build aborts if any page fails to import, printing <code>Failed to import N 
 
 == Fetching fails over HTTPS ==
 
-Fetching Wikimedia Commons images and [[wikven.yaml#WikvenRepositories|third-party extensions or skins]] needs your system's CA certificates. On a minimal host without them (common with the standalone binary), install your distribution's CA bundle, for example the <code>ca-certificates</code> package. A site with only local content and images needs no network access.
+Fetching Wikimedia Commons images and [[Configuration#WikvenRepositories|third-party extensions or skins]] needs your system's CA certificates. On a minimal host without them (common with the standalone binary), install your distribution's CA bundle, for example the <code>ca-certificates</code> package. A site with only local content and images needs no network access.
 
 == The binary will not run on macOS or Windows ==
 
 The standalone binary is Linux-only (x86_64 and arm64). On macOS or Windows, use the Docker image instead. See [[Installation]].
 
-{{prevnext|Deploying|wikven.yaml}}
+{{prevnext|Deploying|Configuration}}

--- a/docs/Why wikitext.wikitext
+++ b/docs/Why wikitext.wikitext
@@ -8,7 +8,7 @@ __TOC__
 * '''{{ml|Help:Parser functions|Parser functions}} and magic words''' — light logic and computed values (<code><nowiki>{{#if:}}</nowiki></code>, dates, page info) written in the page itself.
 * '''Structured linking''' — <code><nowiki>[[Page]]</nowiki></code> internal links, {{ml|Help:Categories|categories}} and redirects, managed by the wiki rather than by hand.
 * '''Rich media and references''' — image {{ml|Help:Images|thumbnails and galleries}} and footnotes in one consistent syntax.
-* '''An extension ecosystem''' — syntax highlighting, math and more, added as [[wikven.yaml|extensions]].
+* '''An extension ecosystem''' — syntax highlighting, math and more, added as [[Configuration|extensions]].
 
 == What Markdown does better ==
 

--- a/docs/index.wikitext
+++ b/docs/index.wikitext
@@ -24,7 +24,7 @@ With {{wikven}}, you can use the following features of MediaWiki.
 * [[Images]] from Wikimedia Commons or local files
 * [[JavaScript]] (MediaWiki:Common.js and gadgets)
 * {{ml|Bundled extensions and skins}}
-* Third-party extensions and skins (see [[wikven.yaml|.wikven.yaml]])
+* Third-party extensions and skins (see [[Configuration|.wikven.yaml]])
 * [[Searching|Search]] (client-side, via the SifterSearch extension)
 
 == Unsupported features ==


### PR DESCRIPTION
The newcomer review noted the config page went by three names: **Configuration** (sidebar), **.wikven.yaml** (display title), and **wikven.yaml** (URL and links).

This renames the page to **Configuration**, so the page has a single name everywhere, URL, title, sidebar, and link targets. `.wikven.yaml` now appears only as the literal file name in prose and link text (e.g. "create a `.wikven.yaml` file"), which is correct. The intro names the `.wikven.yaml` file so the renamed page still says what it documents.

All `[[wikven.yaml…]]` links (including `#WikvenRepositories` anchors) and the prev/next target were repointed; a grep confirms no `wikven.yaml` page reference remains. The smoke test builds the docs, so a broken link's page would fail to import only if invalid, but red links are visually verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)