### PR TITLE
docs: polish from the third newcomer review

### DIFF
--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -64,4 +64,3 @@ The binary renders on its own, but uses these host programs when they are presen
 {{note|Fetching over HTTPS, Wikimedia Commons images via InstantCommons and any [[Configuration#WikvenRepositories|third-party extensions or skins]], relies on your system's CA certificates. On a minimal system without them, install your distribution's CA bundle (for example the <code>ca-certificates</code> package). A site with only local content and images needs no network access.}}
 
 {{prevnext|Pages|Editing sidebar}}
-{{DISPLAYTITLE:Standalone binary}}

--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -37,7 +37,7 @@ jobs:
 
 Enable Pages for the repository under '''Settings → Pages → Build and deployment → Source: GitHub Actions'''. This documentation site is published this way.
 
-{{note|A GitHub '''project''' page is served from a subdirectory (<code>username.github.io/repo/</code>). Page-to-page links keep working because {{wikven}} writes them relative, but anything that needs an absolute path, in particular [[Searching|search]], must be told that base path. A '''user/organization''' page (served at the domain root) needs no such setting.}}
+{{note|A GitHub '''project''' page is served from a subdirectory (<code>username.github.io/repo/</code>). Page-to-page links keep working because {{wikven}} writes them relative, but anything that needs an absolute path must include that base path: set [[Searching|search]]'s <code>SifterSearchBundlePath</code> to <code>/repo/pagefind/</code> (this site uses <code>/wikven/pagefind/</code>). A '''user/organization''' page (served at the domain root) needs no such setting.}}
 
 == Any static host ==
 

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -5,7 +5,7 @@
 ** Installation|Installation
 ** Getting Started|Getting Started
 ** Pages|Pages
-** Binary|Standalone binary
+** Binary|Binary
 ** Editing sidebar|Editing sidebar
 ** Images|Images
 ** Skins|Skins
@@ -16,5 +16,6 @@
 * References
 ** Configuration|Configuration
 ** Development|Development
+** Version|Version
 *
 ** helppage|help-mediawiki

--- a/docs/Searching.wikitext
+++ b/docs/Searching.wikitext
@@ -24,7 +24,7 @@ config:
     # The release tarball bundles the Pagefind binary, which a git clone omits.
     # Pick the tarball for the platform the build runs on.
     SifterSearch:
-      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.2.0/SifterSearch-linux-x64.tar.gz
+      tarball: https://github.com/chaotic-ground/SifterSearch/releases/download/v0.5.0/SifterSearch-linux-x64.tar.gz
 </syntaxhighlight>
 
 <code>SifterSearchOutputDir</code> is a filesystem path inside the build output (the image writes the site to <code>/workspace/dist</code>); <code>SifterSearchBundlePath</code> is the URL it is served from. If your site lives in a subdirectory, include it: this site deploys under <code>/wikven</code> on GitHub Pages, so it uses <code>/wikven/pagefind/</code>.

--- a/docs/Skins.wikitext
+++ b/docs/Skins.wikitext
@@ -20,7 +20,7 @@ skins:
 
 == Third-party skins ==
 
-A skin that is not bundled can be listed in <code>skins</code> too, with its source declared in [[Configuration#WikvenRepositories|<code>WikvenRepositories</code>]]. It is fetched at build time and may be the default like any other.
+A skin that is not bundled can be listed in <code>skins</code> too, with its source declared in [[Configuration#WikvenRepositories|<code>WikvenRepositories</code>]]. It is fetched at build time and may be the default like any other. This documentation site does exactly that with the third-party [https://www.mediawiki.org/wiki/Skin:Citizen Citizen] skin.
 
 <syntaxhighlight lang="yaml">
 skins:


### PR DESCRIPTION
Quick fixes from the third newcomer review (findings 2, 3, 5):

- **Searching**: bump the SifterSearch example tarball `v0.2.0` → `v0.5.0` (the current [release](https://github.com/chaotic-ground/SifterSearch/releases); the running version is 0.5.0, so the pasted example was stale).
- **Binary**: drop the `DISPLAYTITLE` so the page is **Binary** everywhere (heading, sidebar, prev/next, URL), instead of "Standalone binary" in some places and "Binary" in others.
- **Deploying**: give the subdirectory base-path note a concrete value (`SifterSearchBundlePath: /repo/pagefind/`) instead of only naming the problem.
- **Skins**: note this site uses the third-party **Citizen** skin, so the Version page listing Citizen no longer seems to contradict the bundled-skins list.
- **Sidebar**: add the generated **Version** page to References, so it is reachable without hunting the footer.

The `:1.0.0` image/action examples are left as-is: they describe the 1.0.0 release the docs ship with and become valid when it is cut.

Finding 1 (dead footer/header links, #158) is a code change handled separately; finding 4 (a worked template example / multi-page walkthrough) is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)