### PR TITLE
fix: drop dead footer/search affordances from the static export

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -52,6 +52,10 @@ config:
   JobRunRate: 0
   ResourceLoaderStorageEnabled: false
 
+  # No RSS/Atom feeds: there is no server to regenerate them, and the head link
+  # to the recent-changes feed points at a Special: page that 404s in the export.
+  Feed: false
+
   # Vector 2022 options. The skin itself is selected in .wikven.yaml via skins:;
   # loading "Vector" defaults to its first variant, vector-2022. (The old
   # VectorDefaultSkinVersion no longer exists in Vector and is not set here.)

--- a/includes/Hooks/Hider.php
+++ b/includes/Hooks/Hider.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\Wikven\Hooks;
 
 use MediaWiki\Extension\Wikven\SourceFile;
+use MediaWiki\Registration\ExtensionRegistry;
 
 class Hider implements
 	\MediaWiki\Hook\ParserOutputPostCacheTransformHook,
@@ -15,9 +16,18 @@ class Hider implements
 
 	/** @inheritDoc */
 	public function onSidebarBeforeOutput($skin, &$sidebar): void {
+		// The toolbox is all server/special-page tools that a static export cannot
+		// serve. The search portlet is dropped too, unless SifterSearch provides
+		// static search and a skin renders its box here (rather than in the header,
+		// like Vector): then keep it so SifterSearch has a box to wire, matching how
+		// the header search box is kept (see Adder and rewriteScripts).
+		$keys = ['TOOLBOX'];
+		if (!ExtensionRegistry::getInstance()->isLoaded('SifterSearch')) {
+			$keys[] = 'SEARCH';
+		}
 		// Empty rather than unset: some skins (e.g. Minerva) read these keys and
 		// require them to stay arrays.
-		foreach (['TOOLBOX', 'SEARCH'] as $key) {
+		foreach ($keys as $key) {
 			if (isset($sidebar[$key])) {
 				$sidebar[$key] = [];
 			}

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -58,6 +58,7 @@ class Build extends Maintenance {
 		$this->step(ImportWikitext::class, "$own/importWikitext.php");
 		$this->assertMainPageExists();
 		$this->setVersionPage();
+		$this->dropDeadFooterPlaces();
 		$this->step(RunJobs::class, "$ip/maintenance/runJobs.php");
 
 		$skins = $GLOBALS['wgWikvenSkins'] ?? [];
@@ -222,6 +223,37 @@ class Build extends Maintenance {
 		$content = ContentHandler::makeContent($GLOBALS['wgWikvenMainPage'], $title);
 		$updater->setContent(SlotRecord::MAIN, $content);
 		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Set the main page'));
+	}
+
+	/**
+	 * Drop footer links whose target page was not imported: the about, privacy
+	 * and disclaimer links point at project pages a static export usually has
+	 * none of, so they would 404. A site that wants one just adds the page (e.g.
+	 * a "Wikven:Privacy policy" source file) and the link is kept. The footer
+	 * omits a link when its label message is disabled, so the missing ones get
+	 * their label message blanked to "-" (the SkinAddFooterLinks hook only adds,
+	 * it cannot remove these defaults). Runs after import so the pages exist.
+	 */
+	private function dropDeadFooterPlaces(): void {
+		// Label message (the MediaWiki: page that controls whether the link
+		// shows) => page-name message (whose page the link points at).
+		$places = [
+			'Privacy' => 'privacypage',
+			'Aboutsite' => 'aboutpage',
+			'Disclaimers' => 'disclaimerpage'
+		];
+		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
+		foreach ($places as $label => $pageMessage) {
+			$target = Title::newFromText(wfMessage($pageMessage)->inContentLanguage()->text());
+			if ($target && $target->exists()) {
+				continue;
+			}
+			$title = Title::newFromText("MediaWiki:$label");
+			$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
+			$updater = $page->newPageUpdater($user);
+			$updater->setContent(SlotRecord::MAIN, ContentHandler::makeContent('-', $title));
+			$updater->saveRevision(CommentStoreComment::newUnsavedComment('Disable dead footer link'));
+		}
 	}
 
 	/**


### PR DESCRIPTION
The static export emitted links that 404, because the static site has no such pages (the third newcomer review's top finding, #158). This also fixes an over-aggressive removal found while auditing for the same pattern.

## Changes

- **Footer about / privacy / disclaimer** point at project pages a static export usually lacks. Drop each **only when its target page was not imported** (blank the label message after import). A site that wants one just adds the page (e.g. a `Wikven:Privacy policy` source file) and the link is kept, so the capability is preserved, not removed. The `SkinAddFooterLinks` hook only *adds* (it is handed a fresh array), so it cannot remove these defaults; the message route is the way.
- **Recent-changes Atom feed** head link points at `Special:RecentChanges`, which a static export cannot regenerate. `Feed: false`.
- **Search portlet** was emptied *unconditionally*, even though the header search box and the Vector Vue box are kept when SifterSearch provides static search. Keep the portlet too in that case, so a skin that renders its search box there (rather than in the header, like Vector) still has one for SifterSearch to wire. This is the same "don't unconditionally remove a working capability" fix as the footer.

## Audit

Prompted by the footer case, I swept every removal/hide point. The rest are justified (server-only features a static site genuinely cannot offer): personal tools, the toolbox, the `opensearch`/`rsd`/`universal-edit-button` head links, the Vector appearance widget (lazy-loads from `load.php`), `Feed`, `JobRunRate`. Already conditional and correct: edit/history/view-source tabs (`SourceFile::exists` + URLs), `#p-search`, the Vector Vue search box, the Version page, and File: → Commons.

## Verified

Built the docs locally: the three footer links and the feed link are gone, `footer-places-source`/`-version` are kept. `php -l`, `mago`, `phpcs`, `minus-x` clean.

Not in scope: the header search box's `Special:Search` full-text fallback link (only present with SifterSearch, skin-specific); tracked for follow-up.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)