### PR TITLE
fix: fail on un-localized images and hand output back to the host user

### DIFF
--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -31,6 +31,9 @@ class StoreImages extends Maintenance {
 		$this->addDescription('Make referenced images local and point the pages at the local copies.');
 	}
 
+	/**
+	 * @return bool Whether every referenced image was made local.
+	 */
 	public function execute() {
 		global $wgWikvenHtmlDirectory, $wgUploadPath, $wgUploadDirectory;
 		$dir = rtrim($wgWikvenHtmlDirectory, '/');
@@ -88,6 +91,15 @@ class StoreImages extends Maintenance {
 		$stored = count(array_filter($map));
 		$failed = count($map) - $stored;
 		$this->output("Stored $stored image(s)" . ( $failed ? ", $failed failed" : '' ) . "\n");
+
+		if ($failed) {
+			// The export still hotlinks the images that could not be fetched, so it
+			// is not self-contained; fail so the build (build.php's step()) aborts
+			// rather than publish output that depends on upload.wikimedia.org.
+			$this->error("Wikven: $failed image(s) could not be made local; the output is not self-contained.");
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/run
+++ b/run
@@ -42,3 +42,10 @@ grep -qF "require_once 'WikvenSettings.php';" LocalSettings.php \
 
 php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/build.php
 rm -rf "$WIKVEN_WORKDIR/dist/history/"
+
+# The build runs as root, so its output is root-owned on the host bind mount.
+# Hand it back to whoever owns the mounted output directory (the invoking user),
+# so they can read, edit, and clean dist/ without sudo.
+if [ -d "$WIKVEN_WORKDIR/dist" ]; then
+  chown -R "$(stat -c '%u:%g' "$WIKVEN_WORKDIR/dist")" "$WIKVEN_WORKDIR/dist"
+fi


### PR DESCRIPTION
Two output papercuts from the v1 review.

## #145 — exit non-zero when the output is not self-contained

`StoreImages` left the live `upload.wikimedia.org` hotlink in place when an image could not be fetched, yet still exited 0, so a build whose output is **not** self-contained reported success. It now returns `false` when any image could not be made local, so `build.php`'s `step()` aborts (the same loud-failure path as a failed import, #132). The per-URL `failed: <url>` lines and the `Stored N, M failed` summary are unchanged.

## #143 — output owned by the invoking user, not root

The container builds as root, so `dist/` came back **root-owned** on the host bind mount and a user following the documented `docker run -v ... dist` needed `sudo` to clean or edit their own output. The run script now `chown`s the output to whoever owns the mounted `dist` directory at the end of the build. The build still runs as root (the privilege angle is, per the issue, not a blocker); this fixes the concrete papercut.

## Verified

Local Docker build: `dist/` and its files come back `1000:1000` (the host user) instead of `0:0`, and can be removed without `sudo`. A normal build (Commons images reachable) still succeeds. `php -l`, `bash -n`, `mago`, `phpcs`, `minus-x` clean.

Closes #145
Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)