### PR TITLE
chore: internalize the WIKVEN_WORKDIR-derived path config keys

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -55,10 +55,6 @@
 		}
 	},
 	"config": {
-		"WikvenSourceDirectory": {
-			"value": "/workspace/src",
-			"description": "Path to the source directory where wikitext files are"
-		},
 		"WikvenMainPage": {
 			"value": "index",
 			"description": "Title of the page used as the wiki's main page, i.e. the static site root (written as <value>.html). Must be an imported page."
@@ -67,17 +63,13 @@
 			"value": "Version",
 			"description": "Title of an auto-generated page (mirroring Special:Version) listing the installed software, extensions and skins, linked from the footer. Empty disables it; a same-named source page takes precedence."
 		},
-		"WikvenHtmlDirectory": {
-			"value": "/workspace/dist",
-			"description": "Path to the dist directory of HTML files."
-		},
 		"WikvenStyleDirectory": {
 			"value": ".",
-			"description": "Relative Path to the dist directory of CSS files from $wgWikvenHtmlDirectory."
+			"description": "Relative path to the dist directory of CSS files, under the WIKVEN_WORKDIR output directory."
 		},
 		"WikvenScriptDirectory": {
 			"value": ".",
-			"description": "Relative path to the dist directory of JS files from $wgWikvenHtmlDirectory."
+			"description": "Relative path to the dist directory of JS files, under the WIKVEN_WORKDIR output directory."
 		},
 		"WikvenFooterUrl": {
 			"value": "",


### PR DESCRIPTION
`WikvenSourceDirectory` and `WikvenHtmlDirectory` were declared as user `config` in `extension.json`, but `WikvenSettings.php` sets both globals unconditionally from `WIKVEN_WORKDIR`, so a `.wikven.yaml` override was only half-honored (it moved the file-cache write while cleanup and the binary's path checks still used `WIKVEN_WORKDIR`).

Since they aren't documented as user-settable and their declared defaults equal the effective default, remove them from the config surface rather than freeze a half-wired knob at 1.0.0 (later making it work or removing it would both be breaking).

The globals are unchanged: `WikvenSettings.php` still sets `$wgWikvenSourceDirectory`/`$wgWikvenHtmlDirectory`, and every reader uses the global (directly or via the global-backed Config in `Main.php`), so behavior is identical. Setting these in `.wikven.yaml` now warns as an unknown Wikven key. `WikvenStyleDirectory`/`WikvenScriptDirectory` stay (relative output subdirs, not `WIKVEN_WORKDIR`-governed).

Verified with a local Docker build: the site builds and styles dump correctly with the keys removed.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)