### PR TITLE
fix: validate .wikven.yaml value shapes and flag warnings clearly

### DIFF
--- a/WikvenSettings.php
+++ b/WikvenSettings.php
@@ -141,7 +141,7 @@ if ($wikvenSiteFile !== null) {
 	$wikvenSiteData = $wikvenSiteFormat->decode(file_get_contents($wikvenSiteFile));
 	$wikvenSiteName = basename($wikvenSiteFile);
 	foreach (MediaWiki\Extension\Wikven\SiteConfig::lint($wikvenSiteData, $wikvenKnownConfig) as $wikvenWarning) {
-		error_log("Wikven: $wikvenSiteName $wikvenWarning");
+		error_log("Wikven: WARNING in $wikvenSiteName: $wikvenWarning");
 	}
 }
 

--- a/includes/SiteConfig.php
+++ b/includes/SiteConfig.php
@@ -12,9 +12,11 @@ class SiteConfig {
 	/**
 	 * Lint decoded site-config contents, returning a warning for each mistake the
 	 * settings system would otherwise drop silently: an unknown top-level key, a
-	 * wrong-typed config/extensions/skins, or a misspelled Wikven variable (which
-	 * would set a global nothing reads). Messages are returned rather than logged
-	 * so the check stays pure and unit-testable.
+	 * wrong-typed config/extensions/skins, a misspelled Wikven variable (which
+	 * would set a global nothing reads), or a Wikven value of the wrong shape (a
+	 * URL template missing its $1 placeholder, a non-map logos/repositories).
+	 * Messages are returned rather than logged so the check stays pure and
+	 * unit-testable.
 	 *
 	 * @param mixed $data Decoded .wikven.yaml/.json contents.
 	 * @param string[] $knownConfig Canonical Wikven config variable names, from extension.json.
@@ -39,9 +41,25 @@ class SiteConfig {
 			$warnings[] = "'config' must be a map.";
 			return $warnings;
 		}
-		foreach (array_keys($data['config'] ?? []) as $cfgKey) {
+		$config = $data['config'] ?? [];
+		foreach (array_keys($config) as $cfgKey) {
 			if (str_starts_with($cfgKey, 'Wikven') && !in_array($cfgKey, $knownConfig, true)) {
 				$warnings[] = "unknown config '$cfgKey' (not a Wikven variable; typo?).";
+			}
+		}
+
+		// Value-shape checks for the Wikven keys whose shape matters, so a wrong
+		// type or a URL template missing its $1 placeholder is caught here rather
+		// than silently producing broken links or being dropped.
+		foreach (['WikvenEditUrl', 'WikvenHistoryUrl', 'WikvenViewSourceUrl'] as $urlKey) {
+			$value = $config[$urlKey] ?? '';
+			if ($value !== '' && ( !is_string($value) || !str_contains($value, '$1') )) {
+				$warnings[] = "'$urlKey' should be a URL template containing \$1 (replaced by the source file name).";
+			}
+		}
+		foreach (['WikvenLogos', 'WikvenRepositories'] as $mapKey) {
+			if (isset($config[$mapKey]) && !is_array($config[$mapKey])) {
+				$warnings[] = "'$mapKey' must be a map.";
 			}
 		}
 		return $warnings;

--- a/tests/phpunit/unit/SiteConfigTest.php
+++ b/tests/phpunit/unit/SiteConfigTest.php
@@ -13,11 +13,22 @@ class SiteConfigTest extends MediaWikiUnitTestCase {
 
 	public function testSoundFileHasNoWarnings() {
 		$data = [
-			'config' => ['WikvenEditUrl' => 'x', 'Sitename' => 'S'],
+			'config' => ['WikvenEditUrl' => 'https://example.org/edit/$1', 'Sitename' => 'S'],
 			'extensions' => ['Foo'],
 			'skins' => ['Vector']
 		];
 		$this->assertSame([], SiteConfig::lint($data, self::KNOWN));
+	}
+
+	public function testUrlTemplateMissingPlaceholderWarns() {
+		$warnings = SiteConfig::lint(['config' => ['WikvenEditUrl' => 'https://example.org/edit']], self::KNOWN);
+		$this->assertCount(1, $warnings);
+		$this->assertStringContainsString("'WikvenEditUrl' should be a URL template containing", $warnings[0]);
+	}
+
+	public function testNonMapValueWarns() {
+		$warnings = SiteConfig::lint(['config' => ['WikvenLogos' => 'logo.png']], self::KNOWN);
+		$this->assertContains("'WikvenLogos' must be a map.", $warnings);
 	}
 
 	public function testNonMapIsRejected() {


### PR DESCRIPTION
The `.wikven.yaml` linter only spell-checked `Wikven`-prefixed keys and coarse types, so a Wikven value of the **wrong shape** passed through and silently produced broken output:

- an edit/history/view-source URL template with no `$1` placeholder (so the source-file name is never substituted), or
- a scalar where a `WikvenLogos` / `WikvenRepositories` **map** is expected.

## Changes

- `SiteConfig::lint` now checks those value shapes (the three URL templates contain `$1`; logos/repositories are maps), returning a clear warning for each.
- Warnings are emitted with a `WARNING` prefix so a dropped/invalid setting stands out in the build log.
- Unit tests for the new checks; the existing "sound file" test now uses a valid `$1` template.

Out of scope (per the issue): validating the open-ended MediaWiki config map against the full settings schema, and failing the build, the warn-don't-fail behavior is a deliberate, codebase-wide choice.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)