### PR TITLE
docs: add a worked template example and a second-page step

### DIFF
--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -49,4 +49,15 @@ EOF
 
 Build again with the same command as before, and the site is titled "My Site".
 
+== Adding a second page ==
+
+Every <code>.wikitext</code> file becomes a page. Add another one and link to it from the first with <code><nowiki>[[...]]</nowiki></code>:
+
+<syntaxhighlight lang="shell">
+echo 'This is the help page.' > src/Help.wikitext
+echo 'Read the [[Help]].' >> src/index.wikitext
+</syntaxhighlight>
+
+Build again: the home page now links to <code>Help.html</code>, and the link works with no server. See [[Pages]] for how file names map to page titles and namespaces, and for [[Pages#Templates|templates]].
+
 {{prevnext|Installation|Pages}}

--- a/docs/Pages.wikitext
+++ b/docs/Pages.wikitext
@@ -28,6 +28,18 @@ Prefix the file name with a namespace to place the page there:
 
 == Templates ==
 
-Put a <code>Template:Name.wikitext</code> file in your source and use it on any page as <code><nowiki>{{Name}}</nowiki></code>, with parameters and {{ml|Help:Parser functions|parser functions}} exactly as in MediaWiki. This site's pages transclude such templates, for example a <code>Template:wikven</code> that renders "{{wikven}}". The syntax itself is standard MediaWiki; see {{ml|Help:Templates}}.
+Put a <code>Template:Name.wikitext</code> file in your source and use it on any page as <code><nowiki>{{Name}}</nowiki></code>. For example, this file:
+
+<syntaxhighlight lang="wikitext">
+'''Note:''' {{{1}}}
+</syntaxhighlight>
+
+saved as <code>Template:Note.wikitext</code> and used on a page as:
+
+<syntaxhighlight lang="wikitext">
+{{Note|Back up your wiki first.}}
+</syntaxhighlight>
+
+renders as "'''Note:''' Back up your wiki first." Templates take positional (<code><nowiki>{{{1}}}</nowiki></code>) and named parameters and run {{ml|Help:Parser functions|parser functions}} exactly as in MediaWiki; this site's own pages transclude a <code>Template:wikven</code> that renders "{{wikven}}". The syntax itself is standard MediaWiki; see {{ml|Help:Templates}}.
 
 {{prevnext|Getting Started|Binary}}


### PR DESCRIPTION
The third newcomer review's onboarding-depth finding: templates are the headline reason to choose wikven, yet had **no worked example**, and Getting Started stopped at a single page.

- **Pages → Templates**: a copy-pasteable `Template:Note` example, the file's contents, how it's used (`{{Note|...}}`), and what it renders to. The syntax itself still defers to mediawiki.org.
- **Getting Started → Adding a second page**: a short step that creates a second `.wikitext` file and links to it with `[[...]]`, so the quickstart reaches a real multi-page site, then points at [[Pages]] for the file-name-to-title rules.

Per the project's steer, these add only the wikven-specific worked path; general wikitext/template syntax stays linked to mediawiki.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)