### PR TITLE
ci: publish a checksum and build provenance for the release binaries

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write # gh release upload
+      id-token: write # sign the build provenance attestation
+      attestations: write # write the build provenance attestation
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -53,8 +55,16 @@ jobs:
       - name: Name it per architecture
         run: mv out/wikven "wikven-linux-${{ matrix.arch }}"
 
+      - name: Generate the checksum
+        run: sha256sum "wikven-linux-${{ matrix.arch }}" > "wikven-linux-${{ matrix.arch }}.sha256"
+
+      # Signed SLSA provenance, so users can `gh attestation verify` the binary.
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: wikven-linux-${{ matrix.arch }}
+
       - name: Attach to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}
-        run: gh release upload "$TAG" "wikven-linux-${{ matrix.arch }}" --clobber
+        run: gh release upload "$TAG" "wikven-linux-${{ matrix.arch }}" "wikven-linux-${{ matrix.arch }}.sha256" --clobber

--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -20,6 +20,22 @@ tag=$(curl -s https://api.github.com/repos/chaotic-ground/wikven/releases | sed 
 curl -L -o wikven "https://github.com/chaotic-ground/wikven/releases/download/$tag/wikven-linux-x86_64"
 </syntaxhighlight>
 
+== Verify ==
+
+Each release binary is published with a <code>.sha256</code> checksum and a signed build-provenance attestation. To check it before trusting a binary you install onto your <code>PATH</code>, download it under its release name and verify the checksum:
+
+<syntaxhighlight lang="shell">
+curl -LO https://github.com/chaotic-ground/wikven/releases/latest/download/wikven-linux-x86_64
+curl -LO https://github.com/chaotic-ground/wikven/releases/latest/download/wikven-linux-x86_64.sha256
+sha256sum -c wikven-linux-x86_64.sha256
+</syntaxhighlight>
+
+Or verify the provenance, that GitHub Actions built it from this repository, with the [https://cli.github.com/ GitHub CLI]:
+
+<syntaxhighlight lang="shell">
+gh attestation verify wikven-linux-x86_64 --repo chaotic-ground/wikven
+</syntaxhighlight>
+
 == Install ==
 
 The downloaded file already runs as-is — <code>./wikven</code> from the directory you saved it in. To run it as plain <code>wikven</code> from anywhere, install it onto your <code>PATH</code>:


### PR DESCRIPTION
The standalone binaries, a headline 1.0.0 distribution channel users `sudo install` onto their PATH, shipped with **no** integrity or provenance material, and the install docs verified nothing.

## Changes

- `build-binary.yaml` writes `wikven-linux-<arch>.sha256` next to each binary and uploads it to the release.
- It attests signed SLSA build provenance via `actions/attest-build-provenance` (pinned), adding `id-token: write` + `attestations: write` to the job, so users can `gh attestation verify`.
- The **Binary** page gains a **Verify** section: `sha256sum -c` and `gh attestation verify`.

`actionlint` clean, `zizmor` no findings. The workflow is `workflow_call`-only (release-please / nightly), so the checksum/attestation only materialize on a real release.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)