### PR TITLE
chore: declare the GPL-3.0-or-later license in composer.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ want and record its version in the trailing comment. It runs the published Docke
 image; pin a release tag (e.g. `ghcr.io/chaotic-ground/wikven:1.0.0`) via the `image`
 input for reproducible builds.
 
+## License
+
+[GPL-3.0-or-later](LICENSE).
+
 [![Lint](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml/badge.svg)](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml)
 [![codecov](https://codecov.io/gh/chaotic-ground/wikven/graph/badge.svg)](https://codecov.io/gh/chaotic-ground/wikven)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "chaotic-ground/wikven",
 	"type": "mediawiki-extension",
+	"license": "GPL-3.0-or-later",
 	"scripts": {
 		"test": "minus-x check .",
 		"fix": "minus-x fix .",


### PR DESCRIPTION
The repo ships a GPL-3.0 `LICENSE` and `extension.json` declares `"license-name": "GPL-3.0-or-later"`, but `composer.json` had no `license` field and the README never stated the license, a simple omission.

- `composer.json`: add `"license": "GPL-3.0-or-later"` (`composer validate` passes).
- `README.md`: add a **License** section pointing at `LICENSE`.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)