### PR TITLE
docs: attribute the redistributed third-party software

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ input for reproducible builds.
 
 ## License
 
-[GPL-3.0-or-later](LICENSE).
+[GPL-3.0-or-later](LICENSE). The Docker image and binary bundle third-party software under their own licenses; see [Third-party software](https://chaotic-ground.github.io/wikven/Third-party_software).
 
 [![Lint](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml/badge.svg)](https://github.com/chaotic-ground/wikven/actions/workflows/lint.yaml)
 [![codecov](https://codecov.io/gh/chaotic-ground/wikven/graph/badge.svg)](https://codecov.io/gh/chaotic-ground/wikven)

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -17,5 +17,6 @@
 ** Configuration|Configuration
 ** Development|Development
 ** Version|Version
+** Third-party software|Third-party software
 *
 ** helppage|help-mediawiki

--- a/docs/Third-party software.wikitext
+++ b/docs/Third-party software.wikitext
@@ -1,0 +1,19 @@
+__TOC__
+
+{{wikven}} itself is licensed [https://github.com/chaotic-ground/wikven/blob/main/LICENSE GPL-3.0-or-later]. The Docker image and the standalone binary it produces redistribute third-party software under that software's own licenses, acknowledged here. (GPL-2.0-or-later and GPL-3.0-or-later are compatible, so this is attribution, not a conflict.)
+
+{| class="wikitable"
+! Component !! License !! Bundled in
+|-
+| [https://www.mediawiki.org/ MediaWiki], with its bundled skins and extensions || GPL-2.0-or-later || image, binary
+|-
+| [https://www.php.net/ PHP] || PHP License 3.01 || binary
+|-
+| [https://frankenphp.dev/ FrankenPHP] || MIT || binary
+|-
+| [https://caddyserver.com/ Caddy] || Apache-2.0 || binary
+|-
+| [https://getcomposer.org/ Composer] || MIT || image
+|}
+
+The standalone binary is compiled with [https://frankenphp.dev/ FrankenPHP], which also links several Caddy modules; see the FrankenPHP project for their licenses. The Docker image keeps MediaWiki's own <code>COPYING</code>, and each component's full license text is available from its project.


### PR DESCRIPTION
The Docker image and standalone binary embed substantial third-party software (MediaWiki, PHP, FrankenPHP, Caddy, Composer) but the project gave no aggregated attribution.

Per the steer that a separate `NOTICE` file is less accessible than the places people actually read, this adds a **Third-party software** page to the docs site, a table of each redistributed component and its license, linked from the README's **License** section and the docs sidebar.

| Component | License | Bundled in |
|---|---|---|
| MediaWiki (+ bundled skins/extensions) | GPL-2.0-or-later | image, binary |
| PHP | PHP License 3.01 | binary |
| FrankenPHP | MIT | binary |
| Caddy | Apache-2.0 | binary |
| Composer | MIT | image |

The binary's FrankenPHP build also links several Caddy modules; the page points at the FrankenPHP project for those rather than asserting each module's license (one, `dunglas/mercure`, may be AGPL, flagged separately for legal review, and is a candidate to trim since the build doesn't use the Mercure server).

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)