### PR TITLE
test: cover the Main, Hider and Adder hooks

### DIFF
--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\Hooks\Adder;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Skin\Skin;
+use MediaWikiIntegrationTestCase;
+use Wikimedia\TestingAccessWrapper;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Hooks\Adder
+ */
+class AdderTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * The footer project link shows a friendly host name for known forges and the
+	 * bare host otherwise, so it is not hardcoded to GitHub.
+	 *
+	 * @dataProvider provideRepoHosts
+	 */
+	public function testRepoHostName(string $url, ?string $expected) {
+		$adder = TestingAccessWrapper::newFromObject(new Adder());
+		$this->assertSame($expected, $adder->repoHostName($url));
+	}
+
+	public static function provideRepoHosts() {
+		return [
+			'github' => ['https://github.com/owner/repo', 'GitHub'],
+			'gitlab with www' => ['https://www.gitlab.com/owner', 'GitLab'],
+			'codeberg' => ['https://codeberg.org/owner', 'Codeberg'],
+			'unknown host kept as-is' => ['https://git.example.org/owner', 'git.example.org'],
+			'no host' => ['not a url', null]
+		];
+	}
+
+	/**
+	 * The footer gains a link to the project repository when WikvenFooterUrl is
+	 * set, but only for the "places" category and not for others.
+	 */
+	public function testFooterAddsSourceLink() {
+		$this->overrideConfigValue('WikvenFooterUrl', 'https://github.com/owner/repo');
+		$this->overrideConfigValue('WikvenSkins', ['vector']);
+
+		$footerItems = [];
+		( new Adder() )->onSkinAddFooterLinks($this->skin(), 'places', $footerItems);
+		$this->assertArrayHasKey('source', $footerItems);
+		$this->assertStringContainsString('github.com/owner/repo', $footerItems['source']);
+
+		$other = ['existing' => 'kept'];
+		( new Adder() )->onSkinAddFooterLinks($this->skin(), 'info', $other);
+		$this->assertSame(['existing' => 'kept'], $other, 'only the places category is touched');
+	}
+
+	/**
+	 * The header search box has no backend on a static site, so it is hidden
+	 * unless SifterSearch (not loaded here) provides static search.
+	 */
+	public function testHidesSearchBoxWithoutSifterSearch() {
+		$this->overrideConfigValue('WikvenSkins', ['vector']);
+		$out = $this->createMock(OutputPage::class);
+		$out->expects($this->once())
+			->method('addInlineStyle')
+			->with($this->stringContains('#p-search'));
+		$skin = $this->createMock(Skin::class);
+		$skin->method('getSkinName')->willReturn('vector');
+
+		( new Adder() )->onBeforePageDisplay($out, $skin);
+	}
+
+	private function skin(): Skin {
+		$skin = $this->createMock(Skin::class);
+		$skin->method('msg')->willReturnCallback(static function (string $key, ...$params) {
+			return wfMessage($key, ...$params);
+		});
+		$skin->method('getSkinName')->willReturn('vector');
+		return $skin;
+	}
+}

--- a/tests/phpunit/integration/AdderTest.php
+++ b/tests/phpunit/integration/AdderTest.php
@@ -40,6 +40,8 @@ class AdderTest extends MediaWikiIntegrationTestCase {
 	public function testFooterAddsSourceLink() {
 		$this->overrideConfigValue('WikvenFooterUrl', 'https://github.com/owner/repo');
 		$this->overrideConfigValue('WikvenSkins', ['vector']);
+		// Empty so the footer's version-link branch does not query the database.
+		$this->overrideConfigValue('WikvenVersionPage', '');
 
 		$footerItems = [];
 		( new Adder() )->onSkinAddFooterLinks($this->skin(), 'places', $footerItems);

--- a/tests/phpunit/integration/HiderTest.php
+++ b/tests/phpunit/integration/HiderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\Hooks\Hider;
+use MediaWiki\Skin\Skin;
+use MediaWiki\Skin\SkinTemplate;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Hooks\Hider
+ */
+class HiderTest extends MediaWikiIntegrationTestCase {
+	/**
+	 * The static export has no per-section edit affordance, so section edit links
+	 * are turned off.
+	 */
+	public function testSectionEditLinksDisabled() {
+		$text = '';
+		$options = ['enableSectionEditLinks' => true];
+		( new Hider() )->onParserOutputPostCacheTransform(null, $text, $options);
+		$this->assertFalse($options['enableSectionEditLinks']);
+	}
+
+	/**
+	 * The toolbox is server-only tools, and without SifterSearch the search
+	 * portlet cannot work either; both are emptied (not unset, so skins that read
+	 * the keys keep an array), while other sidebar sections are left alone.
+	 */
+	public function testSidebarToolboxAndSearchEmptied() {
+		$sidebar = ['TOOLBOX' => ['tool'], 'SEARCH' => ['box'], 'navigation' => ['keep']];
+		( new Hider() )->onSidebarBeforeOutput($this->createMock(Skin::class), $sidebar);
+		$this->assertSame([], $sidebar['TOOLBOX']);
+		$this->assertSame([], $sidebar['SEARCH'], 'SifterSearch not loaded, so search is dropped');
+		$this->assertSame(['keep'], $sidebar['navigation']);
+	}
+
+	/**
+	 * The navigation always loses the personal tools (no accounts on a static
+	 * site). The edit, source and history tabs are kept only when their URLs are
+	 * configured and the page has a source file behind them; a generated page
+	 * (no source) drops them so they cannot 404.
+	 */
+	public function testNavigationDropsPersonalToolsAndSourcelessTabs() {
+		$dir = $this->getNewTempDirectory();
+		file_put_contents("$dir/Real.wikitext", '');
+		$this->overrideConfigValue('WikvenSourceDirectory', $dir);
+		$this->overrideConfigValue('WikvenEditUrl', 'https://example.org/edit/$1');
+		$this->overrideConfigValue('WikvenHistoryUrl', 'https://example.org/history/$1');
+
+		$imported = $this->navigationFor('Real');
+		$this->assertSame([], $imported['user-menu'], 'personal tools emptied');
+		$this->assertArrayHasKey('edit', $imported['views'], 'imported page keeps its edit tab');
+		$this->assertArrayHasKey('history', $imported['views']);
+		$this->assertArrayHasKey('view', $imported['views'], 'unrelated tabs are left alone');
+
+		$generated = $this->navigationFor('Version');
+		$this->assertArrayNotHasKey('edit', $generated['views'], 'source-less page drops edit');
+		$this->assertArrayNotHasKey('ve-edit', $generated['views']);
+		$this->assertArrayNotHasKey('viewsource', $generated['views']);
+		$this->assertArrayNotHasKey('history', $generated['views']);
+		$this->assertArrayHasKey('view', $generated['views']);
+	}
+
+	private function navigationFor(string $titleText): array {
+		$sktemplate = $this->createMock(SkinTemplate::class);
+		$sktemplate->method('getTitle')->willReturn(Title::newFromText($titleText));
+		$links = [
+			'user-menu' => ['login' => []],
+			'user-page' => ['x'],
+			'user-interface-preferences' => ['x'],
+			'notifications' => ['x'],
+			'views' => [
+				'view' => ['keep'],
+				'edit' => ['x'],
+				've-edit' => ['x'],
+				'viewsource' => ['x'],
+				'history' => ['x']
+			]
+		];
+		( new Hider() )->onSkinTemplateNavigation__Universal($sktemplate, $links);
+		return $links;
+	}
+}

--- a/tests/phpunit/integration/MainTest.php
+++ b/tests/phpunit/integration/MainTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace MediaWiki\Extension\Wikven\Tests\Integration;
+
+use MediaWiki\Extension\Wikven\Hooks\Main;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+
+/**
+ * @covers \MediaWiki\Extension\Wikven\Hooks\Main
+ */
+class MainTest extends MediaWikiIntegrationTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		// Read by Main's constructor; not set outside a build.
+		$this->overrideConfigValue('WikvenHtmlDirectory', $this->getNewTempDirectory());
+		$this->overrideConfigValue('WikvenStyleDirectory', '.');
+	}
+
+	private function main(): Main {
+		return new Main($this->getServiceContainer()->getMainConfig());
+	}
+
+	/**
+	 * A normal page link is rewritten to the relative ./Name.html the static host
+	 * serves, instead of a path that only resolves inside a live MediaWiki.
+	 */
+	public function testNormalPageLink() {
+		$title = Title::newFromText('Getting Started');
+		$url = '/index.php/Getting_Started';
+		$this->main()->onGetLocalURL($title, $url, '');
+		$this->assertSame('./Getting_Started.html', $url);
+	}
+
+	/**
+	 * The edit and history actions are rewritten to the configured repository
+	 * URLs, with $1 replaced by the page's percent-encoded source file name, so a
+	 * reader can jump from the rendered page to its source.
+	 */
+	public function testEditAndHistoryActionsRewritten() {
+		$this->overrideConfigValue('WikvenEditUrl', 'https://repo/edit/$1');
+		$this->overrideConfigValue('WikvenHistoryUrl', 'https://repo/history/$1');
+		$title = Title::newFromText('Getting Started');
+
+		$edit = '/x';
+		$this->main()->onGetLocalURL($title, $edit, 'action=edit');
+		$this->assertSame('https://repo/edit/Getting%20Started.wikitext', $edit);
+
+		$history = '/x';
+		$this->main()->onGetLocalURL($title, $history, 'action=history');
+		$this->assertSame('https://repo/history/Getting%20Started.wikitext', $history);
+	}
+
+	/**
+	 * With no edit URL configured, even an action=edit link falls back to the
+	 * static page rather than a dead query string.
+	 */
+	public function testEditFallsBackWithoutUrl() {
+		$title = Title::newFromText('Getting Started');
+		$url = '/x';
+		$this->main()->onGetLocalURL($title, $url, 'action=edit');
+		$this->assertSame('./Getting_Started.html', $url);
+	}
+}


### PR DESCRIPTION
PHPUnit coverage was limited to the `SourceFile`/`SiteConfig`/`AssetLocalizer` helpers, leaving the hook logic, the part that actually shapes the static export, untested (the codecov number reflects this). Add integration tests for the three hook classes:

- **`Main::onGetLocalURL`**: a normal page rewrites to `./Name.html`; `action=edit`/`action=history` rewrite to the configured repository URLs with the percent-encoded source file name; with no URL set, edit falls back to the static page.
- **`Hider`**: section edit links off; the toolbox and (without SifterSearch) the search portlet emptied while other sidebar sections are kept; personal tools dropped, and the edit/source/history tabs kept for an imported page but dropped for a generated (source-less) one.
- **`Adder`**: `repoHostName` maps known forges and keeps unknown hosts; the footer gains the project link only for the `places` category; the search box is hidden without SifterSearch.

These exercise the branchy logic behind several of this milestone's fixes (#130, #158). The `maintenance/` build scripts remain covered by the end-to-end smoke test rather than unit coverage.

`php -l`, `mago`, `phpcs`, `minus-x` clean. (Coverage status is informational, not blocking.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)