### PR TITLE
docs: hide the tracking categories so the catlinks footer stays clean

### DIFF
--- a/docs/Category:Noindexed pages.wikitext
+++ b/docs/Category:Noindexed pages.wikitext
@@ -1,0 +1,4 @@
+__HIDDENCAT__
+A maintenance tracking category. Defining it as a hidden category keeps it off
+the page footer in the static export, so it does not show readers a link to a
+category page the export does not include.

--- a/docs/Category:Pages using Tabber parser tag.wikitext
+++ b/docs/Category:Pages using Tabber parser tag.wikitext
@@ -1,0 +1,4 @@
+__HIDDENCAT__
+A maintenance tracking category added by the Tabber extension. Defining it as a
+hidden category keeps it off the page footer in the static export, so it does
+not show readers a link to a category page the export does not include.


### PR DESCRIPTION
Getting Started (via `<tabber>`) and Search (via `__NOINDEX__`) gained a visible category footer linking the non-existent `Special:Categories` and red-linked tracking-category pages (`Category:Pages using Tabber parser tag`, `Category:Noindexed pages`) — the docs half of #171.

Define those two tracking categories as **hidden categories** (`__HIDDENCAT__` source pages). A logged-out reader of the static export does not see hidden categories, so the footer (and its dead `Special:Categories` link) disappears. Verified with a local build: no `mw-normal-catlinks` and no `Special:Categories` links remain.

The general wikven-side handling (exporting Category pages and de-linking `Special:Categories` for sites that use real categories) is the remaining part of #171, tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)