### PR TITLE
fix: drop the category footer's dead Special:Categories link

### DIFF
--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -59,6 +59,7 @@ class Build extends Maintenance {
 		$this->assertMainPageExists();
 		$this->setVersionPage();
 		$this->dropDeadFooterPlaces();
+		$this->dropDeadCategoryLink();
 		$this->step(RunJobs::class, "$ip/maintenance/runJobs.php");
 
 		$skins = $GLOBALS['wgWikvenSkins'] ?? [];
@@ -254,6 +255,23 @@ class Build extends Maintenance {
 			$updater->setContent(SlotRecord::MAIN, ContentHandler::makeContent('-', $title));
 			$updater->saveRevision(CommentStoreComment::newUnsavedComment('Disable dead footer link'));
 		}
+	}
+
+	/**
+	 * Drop the dead link from the category footer's "Categories" label, which
+	 * points at the Special:Categories page a static export has no copy of. The
+	 * skin renders the label as plain text when the "pagecategorieslink" message
+	 * resolves to no title, so blank that message. The category entries
+	 * themselves stay as they are: a category with an imported (or exported)
+	 * page keeps its link, one without it is a red link, like any other.
+	 */
+	private function dropDeadCategoryLink(): void {
+		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
+		$title = Title::newFromText('MediaWiki:Pagecategorieslink');
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
+		$updater = $page->newPageUpdater($user);
+		$updater->setContent(SlotRecord::MAIN, ContentHandler::makeContent('', $title));
+		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Drop the dead category link'));
 	}
 
 	/**


### PR DESCRIPTION
## What

A static export has no `Special:Categories` page, yet the skin prefixes each page's category list with a "Categories" label linked to it, so the link 404s. This is the same dead-link class as the footer places and feed links fixed in #158.

This blanks the `pagecategorieslink` message during the build. The skin builds the label by running that message through `Title::newFromText` and links it only when a title comes back; with the message empty it resolves to no title and the skin renders the label as plain text.

The category entries themselves are untouched: a category whose page is exported keeps its link, one without it stays a red link, like any other link to a not-yet-written page (the accepted behavior agreed in #171).

## Verification

Baked a fixture page with a visible `[[Category:Demo]]` through the image. The footer renders:

```html
<div id="mw-normal-catlinks" class="mw-normal-catlinks">Category: <ul><li><a href="./Category:Demo.html" class="new" title="Category:Demo (page does not exist)">Demo</a></li></ul></div>
```

`Special:Categories` links in the output: 0. The label is plain text; the category entry is a red link.

The header search box's dead `Special:Search` fallback (the other half of the original report) is handled in chaotic-ground/SifterSearch#29.

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)