### PR TITLE
docs: refine the categories section after a newcomer review

### DIFF
--- a/docs/Configuration.wikitext
+++ b/docs/Configuration.wikitext
@@ -91,6 +91,10 @@ Each method needs a host tool present at build time: <code>tarball</code> uses <
 
 This very site fetches {{ml|Extension:TabberNeue|TabberNeue}} this way (see its <code>.wikven.yaml</code>): the tabbed Docker/binary command examples on [[Getting Started]] are rendered by the fetched extension. (TemplateStyles, used by this site's templates, is bundled in MediaWiki and so needs no source here.)
 
+=== <code>ContentNamespaces</code> ===
+
+A standard MediaWiki setting ({{ml|Manual:$wgContentNamespaces|<code>$wgContentNamespaces</code>}}) that decides which pages wikven exports: only pages in a content namespace are written to the static site. Wikven defaults it to <code>[0, 6]</code>, the main and File: namespaces, so file description pages are exported without dumping every <code>Template:</code> or <code>MediaWiki:</code> page. Add the Category namespace (<code>14</code>) to export category pages too; see [[Pages#Categories]]. Because a <code>config</code> value replaces the default rather than extending it, list the full set you want, including the defaults you keep.
+
 == Defaults ==
 
 Before reading your <code>.wikven.yaml</code>, Wikven applies its own defaults from a <code>default.yaml</code> bundled with wikven. It is written in the same format as your configuration, so it doubles as a reference for what Wikven sets for you: the site name, page titles kept as written, InstantCommons, local image uploads (including SVG), the Vector 2022 skin options, and so on. Your <code>.wikven.yaml</code> is merged on top, with your <code>config</code> keys overriding the defaults and your <code>extensions</code> and <code>skins</code> appended.

--- a/docs/Pages.wikitext
+++ b/docs/Pages.wikitext
@@ -30,14 +30,16 @@ Prefix the file name with a namespace to place the page there:
 
 Add <code><nowiki>[[Category:Name]]</nowiki></code> to a page to {{ml|Help:Categories|categorise}} it; the categories show in the page footer, as on any wiki.
 
-The category pages themselves are not exported by default. {{wikven}} counts the main and File: namespaces as content (<code>ContentNamespaces</code>), so a footer category is a red link unless you both add the Category namespace and supply its page. To export category pages, add namespace 14 to the list and put a <code>Category:Name.wikitext</code> file in your source:
+A category's own page is not exported by default, though. {{wikven}} writes only ''content'' pages to the static site, and counts just the main and File: namespaces as content. (Namespaces have numeric IDs: main is <code>0</code>, File: is <code>6</code>, and Category is <code>14</code>.) So a footer category links to a <code>Category:Name.html</code> the static host does not serve, a dead link, until you export the category page. To do that, set <code>ContentNamespaces</code> in your [[Configuration#ContentNamespaces|<code>.wikven.yaml</code>]] and add a <code>Category:Name.wikitext</code> file to your source:
 
 <syntaxhighlight lang="yaml">
 config:
   ContentNamespaces: [0, 6, 14]
 </syntaxhighlight>
 
-To keep a maintenance or tracking category off the footer, mark its category page <code><nowiki>__HIDDENCAT__</nowiki></code>; a logged-out reader of the export does not see hidden categories.
+This key replaces the default rather than extending it, so keep <code>0</code> and <code>6</code> in the list, or the main and File: pages stop being exported.
+
+To keep a maintenance or tracking category out of the footer instead, add the <code><nowiki>__HIDDENCAT__</nowiki></code> {{ml|Help:Magic words|magic word}} to its category page; a static export has no logged-in readers, so a hidden category is off the footer for everyone.
 
 == Templates ==
 


### PR DESCRIPTION
## What

A blank-slate newcomer reviewed the Categories section added in #174 and found real friction. This addresses every finding:

- **Name the file and link Configuration.** The `config:` block now reads "set `ContentNamespaces` in your `.wikven.yaml`" and links a new `Configuration#ContentNamespaces` subsection, so the export recipe is followable from the section alone.
- **Map the namespace IDs** (main 0, File: 6, Category 14), which the page otherwise only ever referred to by name.
- **Say the key replaces, not appends** so a reader does not write `[0, 6, 14]` as `[14]` and silently stop exporting main and File: pages.
- **Call the un-exported footer category a dead link**, what it actually is in a static export, instead of the server-wiki term "red link".
- **Tighten `__HIDDENCAT__`**: call it a magic word placed in the page text, and note a static export has no logged-in readers, so a hidden category is off the footer for everyone.

Also adds a `ContentNamespaces` subsection to Configuration so its default (`[0, 6]`) is documented and verifiable, not only asserted in Pages prose.

## Verification

Baked the docs through the image: `Pages.html` links to `Configuration.html#ContentNamespaces`, that anchor exists, and the Help:Magic words link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)