### PR TITLE
fix: grant the release binary job the provenance permissions it needs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -72,7 +72,9 @@ jobs:
   binary:
     needs: prepare
     permissions:
-      contents: write
+      contents: write # gh release upload
+      id-token: write # sign the build provenance attestation
+      attestations: write # write the build provenance attestation
     uses: ./.github/workflows/build-binary.yaml
     with:
       tag: ${{ needs.prepare.outputs.tag }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -31,7 +31,9 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     permissions:
-      contents: write
+      contents: write # gh release upload
+      id-token: write # sign the build provenance attestation
+      attestations: write # write the build provenance attestation
     uses: ./.github/workflows/build-binary.yaml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Problem

Every `release-please` and `nightly` run has failed at startup ("This run likely failed because of a workflow file issue") since #165 (commit `0d8d626`); the last green run was the commit right before it. That silently froze the release pipeline: release-please stopped updating the draft release PR, and a future release would build no binaries.

## Cause

#165 added build provenance to the reusable `build-binary.yaml`, whose `binary` job now requests `id-token: write` and `attestations: write`. GitHub does not let a reusable workflow request **more** permission than its caller grants, and the two callers still granted only `contents: write`:

- `release-please.yaml` → `binary` job
- `nightly.yaml` → `binary` job

so the whole run is rejected before any job starts.

## Fix

Grant those two caller jobs the same `id-token: write` and `attestations: write` that `build-binary.yaml` declares. `docker-build.yaml`'s caller permissions already matched (`contents: read`, `packages: write`), so only the binary callers needed it.

## Note

This is a release-pipeline blocker for v1: it should land before the 1.0.0 release PR is un-drafted. The fix only runs on pushes to `main`, so it is not exercised by this PR's checks; it was diagnosed from the run history (green at `a3b09db`, startup_failure from `0d8d626` onward) and the caller-vs-callee permission rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)