### PR TITLE
chore: drop per-ecosystem labels from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,6 @@ updates:
       composer:
         patterns:
           - "*"
-    labels:
-      - dependencies
-      - composer
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -26,9 +23,6 @@ updates:
       npm:
         patterns:
           - "*"
-    labels:
-      - dependencies
-      - npm
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -40,9 +34,6 @@ updates:
       github-actions:
         patterns:
           - "*"
-    labels:
-      - dependencies
-      - github-actions
   - package-ecosystem: docker
     directory: /
     schedule:
@@ -54,9 +45,6 @@ updates:
       docker:
         patterns:
           - "*"
-    labels:
-      - dependencies
-      - docker
   - package-ecosystem: gomod
     directory: /caddy
     schedule:
@@ -68,6 +56,3 @@ updates:
       gomod:
         patterns:
           - "*"
-    labels:
-      - dependencies
-      - gomod


### PR DESCRIPTION
Every `updates` entry repeated a `labels:` block (`dependencies` + the ecosystem name). Because specifying `labels:` **overrides** Dependabot's default label set, `dependencies` had to be restated in each of the five blocks.

Dropping the block entirely lets Dependabot apply its default `dependencies` label (which it creates if absent) to every PR, removing 15 lines of repetition. The per-ecosystem label (`composer`, `npm`, …) is given up in the trade, but `package-ecosystem` already identifies each PR's source.

### Why not YAML anchors
Dependabot's config parser does not support YAML anchors/aliases or merge keys, and there is no shared-defaults mechanism. Worse, `yamllint --strict` *accepts* anchors (valid YAML), so they would pass CI green while Dependabot rejects the config server-side, a false green that nothing local can catch. Trimming real repetition is the safe lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)