### PR TITLE
docs: collapse code comments to a single concise line each

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,5 @@
 ---
-# Quibble reports coverage from inside the container, so rewrite its paths to the
-# repository layout.
+# Rewrite Quibble's in-container coverage paths to the repository layout.
 fixes:
   - "/workspace/src/extensions/Wikven/::"
 

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -2,9 +2,7 @@
 
 $cfg = require __DIR__ . '/../vendor/mediawiki/mediawiki-phan-config/src/config.php';
 
-// Gadgets is an optional dependency: buildScripts/rewriteScripts reference its
-// classes behind class_exists() guards. Tell phan about it (so the references
-// resolve) without analysing it.
+// Gadgets is optional (referenced behind class_exists guards); phan resolves it without analysing.
 $cfg['directory_list'][] = '../../extensions/Gadgets';
 $cfg['exclude_analysis_directory_list'][] = '../../extensions/Gadgets';
 

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,21 +1,11 @@
 <?xml version="1.0" ?>
 <ruleset>
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
-		<!--
-			Formatting is owned by mago. mago cannot emit MediaWiki's
-			inner-parenthesis spacing (func( $x )), and keeps a class brace on the
-			declaration line even when an implements list wraps, so leave all
-			whitespace and brace placement to mago and skip the sniffs that fight it.
-		-->
+		<!-- Formatting is mago's; skip the whitespace/brace sniffs it cannot match. -->
 		<exclude name="MediaWiki.WhiteSpace.SpaceyParenthesis" />
 		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing" />
 		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeClassBrace" />
-		<!--
-			wikven is a build tool: it shells out to git/composer/curl and to its
-			own maintenance steps (passthru, with escapeshellarg used to do so
-			safely), and uses @ for best-effort filesystem operations whose failure
-			is intentionally ignored.
-		-->
+		<!-- wikven shells out (passthru) and uses @ for best-effort filesystem ops; allow both. -->
 		<exclude name="MediaWiki.Usage.ForbiddenFunctions.passthru" />
 		<exclude name="MediaWiki.Usage.ForbiddenFunctions.escapeshellarg" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />

--- a/.tf/ruleset.tf
+++ b/.tf/ruleset.tf
@@ -8,11 +8,7 @@ resource "github_repository_ruleset" "default" {
   target      = "branch"
   enforcement = "active"
 
-  # Let repository admins and the chaotic-ground/publishers team bypass the
-  # rules. Gated on github_actions: the Actions GITHUB_TOKEN cannot read a
-  # ruleset's bypass actors (they are admin-only), so in CI it sees an empty
-  # set. Declaring them only on local PAT runs keeps both the stateless CI plan
-  # (empty == empty) and local runs (two == two) free of drift.
+  # Declare bypass actors only on local PAT runs; they're admin-only and unreadable by CI's token.
   dynamic "bypass_actors" {
     for_each = var.github_actions ? [] : [
       { actor_id = 5, actor_type = "RepositoryRole" }, # Repository admin
@@ -33,14 +29,12 @@ resource "github_repository_ruleset" "default" {
   }
 
   rules {
-    # Protect the default branch: block deletion and force-pushes, and require a
-    # pull request for every change (so direct pushes to main are not allowed).
+    # Protect default branch: block deletion and force-pushes, and require a PR for every change.
     deletion         = true
     non_fast_forward = true
     update           = false
 
-    # Merge commits are the only allowed merge method, so a linear history must
-    # not be required (requiring it would forbid merge commits).
+    # Merge commits are the only allowed merge method, so linear history must not be required.
     required_linear_history = false
     required_signatures     = false
 
@@ -52,10 +46,7 @@ resource "github_repository_ruleset" "default" {
       required_review_thread_resolution = false
     }
 
-    # Require status checks to pass before a pull request can be merged: the
-    # Lint workflow jobs (.github/workflows/lint.yml) and the semantic pull
-    # request title check. integration_id 15368 is the GitHub Actions app, so
-    # only its check runs satisfy these.
+    # Required: Lint jobs + semantic-pull-request (integration_id 15368 = GitHub Actions app).
     required_status_checks {
       do_not_enforce_on_create             = false
       strict_required_status_checks_policy = false

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,8 +1,5 @@
 ---
-# Strict yamllint: the upstream default ruleset, relaxing only what GitHub
-# Actions makes unavoidable. line-length fits the SHA-pinned `uses:` and the
-# shell `run:` lines; truthy's key check is off so a workflow's `on:` trigger
-# key is not flagged as a boolean. Everything else stays at the strict default.
+# Strict yamllint (upstream default); line-length and truthy.check-keys relaxed for GitHub Actions.
 extends: default
 
 # Lint only our own files; skip whatever git ignores (vendor/, node_modules/).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-# Base images are digest-pinned for reproducible builds; Dependabot keeps the
-# digests current (see .github/dependabot.yml).
+# Base images are digest-pinned for reproducible builds; Dependabot keeps them current.
 FROM composer:2@sha256:7725eb4545c438629ae8bde3ef0bb9a5038ef566126ad878442a69007242d267 AS composer
 
 FROM mediawiki:1.45@sha256:7f9d5c2cc824096367f998e76a00e3f2195546b14fddb268e4218ab7a46c205d
 
-# composer (and unzip, which composer uses to extract dist archives) so that
-# third-party extensions/skins declared in .wikven.yaml can be installed at build
-# time. git/tar/gzip are already in the base image for the git and tarball methods.
+# composer + unzip to install third-party extensions/skins at build time (git/tar/gzip present).
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN apt-get update \
  && apt-get install -y --no-install-recommends unzip \
@@ -16,7 +13,6 @@ COPY ./ /var/www/html/extensions/Wikven
 COPY includes/WikvenSettings.php /var/www/html/
 
 COPY bin/run /usr/local/bin/run
-# The entry point is wikven's run script; the command is the subcommand it
-# dispatches on (default "build"), so `docker run ... <image> serve` previews.
+# Entry point is wikven's run script; the arg is the subcommand (default "build"; "serve" previews).
 ENTRYPOINT ["/usr/local/bin/run"]
 CMD ["build"]

--- a/bin/build.php
+++ b/bin/build.php
@@ -1,29 +1,10 @@
 <?php
-/**
- * Standalone-binary entry point: build the whole static site in one invocation.
- * The `build` Caddy subcommand (see caddy/) runs this through php-cli, so the
- * user-facing command is:
- *
- *   WIKVEN_WORKDIR=/path/to/work  ./wikven build
- *
- * Reads $WIKVEN_WORKDIR/src (input), writes $WIKVEN_WORKDIR/dist (output), and
- * keeps ephemeral state in $WIKVEN_WORKDIR/.cache. WIKVEN_WORKDIR defaults to the
- * current directory.
- *
- * The binary embeds MediaWiki; this script drives the same steps the Docker
- * `run` script does (install, then load WikvenSettings, then fetch third-party
- * components, then build) by re-invoking the binary once per step. It is shipped
- * to the embed root by Dockerfile.binary, so php-cli finds it as "build.php".
- */
+/** Standalone-binary entry point: builds the whole static site in one `./wikven build` run. */
 
 // __DIR__ is the extracted, writable embed root (MediaWiki's $IP).
 $ip = __DIR__;
 
-// Re-invoking the build steps means running the wikven binary again. FrankenPHP
-// leaves PHP_BINARY empty in CLI mode, so resolve the running executable via
-// /proc/self/exe (read inside PHP to get the real path; the literal string
-// "/proc/self/exe" must not be passed to a subshell, where it would resolve to
-// the shell instead).
+// FrankenPHP leaves PHP_BINARY empty in CLI, so resolve the running binary via /proc/self/exe.
 $self = PHP_BINARY;
 if ($self === '' || !is_executable($self)) {
 	$self = @readlink('/proc/self/exe') ?: '';
@@ -41,8 +22,7 @@ $work = rtrim($work, '/');
 putenv("WIKVEN_WORKDIR=$work");
 $_ENV['WIKVEN_WORKDIR'] = $work;
 
-// Static binaries bundle no CA certificates; point openssl at the host bundle so
-// InstantCommons (HTTPS) and git-over-HTTPS work, unless the user set it already.
+// Static binaries ship no CA certs; point openssl at the host bundle for HTTPS unless already set.
 if (getenv('SSL_CERT_FILE') === false) {
 	foreach ([
 		'/etc/ssl/certs/ca-certificates.crt',
@@ -64,16 +44,13 @@ if (!is_dir("$work/src")) {
 @mkdir("$work/dist", 0777, true);
 @mkdir("$work/.cache", 0777, true);
 
-// Start each run from a clean slate: the embed root may persist between runs
-// (same checksum extracts to the same /tmp dir), so drop any prior install.
+// Start clean: the embed root may persist between runs, so drop any prior install.
 @unlink("$ip/LocalSettings.php");
 foreach (glob("$work/.cache/*.sqlite") ?: [] as $stale) {
 	@unlink($stale);
 }
 
-// Run an embedded maintenance script by re-invoking the binary. The script path
-// for php-cli is resolved relative to the embed root, so maintenance/run.php is
-// passed relatively while the scripts it runs are passed as absolute paths.
+// Run embedded maintenance scripts by re-invoking the binary (run.php relative, targets absolute).
 $run = static function (array $args) use ($self, $ip) {
 	$cmd = array_merge([$self, 'php-cli', 'maintenance/run.php'], $args);
 	passthru(implode(' ', array_map('escapeshellarg', $cmd)), $code);

--- a/bin/run
+++ b/bin/run
@@ -1,18 +1,14 @@
 #!/bin/bash
 set -euo pipefail; IFS=$'\n\t'
 
-# Source input and rendered output live under one working dir, matching
-# WikvenSettings.php. Defaults to /workspace, the path the image mounts. Export
-# it so the PHP maintenance children (which read it via getenv) see any override.
+# One working dir for source + output (default /workspace); exported so PHP children inherit it.
 export WIKVEN_WORKDIR="${WIKVEN_WORKDIR:-/workspace}"
 
-# The image's entry point is this script; the first argument selects the
-# command (default "build"), mirroring the standalone binary's subcommands.
+# Entry point of the image; the first arg selects the command (default "build"), like the binary.
 command="${1:-build}"
 
 if [ "$command" = "serve" ]; then
-  # Serve the already-built site for local preview. The container always
-  # listens on 8080; map it to a host port with `docker run -p 8080:8080`.
+  # Serve the built site for local preview; the container listens on 8080.
   exec php -S "0.0.0.0:8080" -t "$WIKVEN_WORKDIR/dist"
 elif [ "$command" != "build" ]; then
   echo "wikven: unknown command '$command'; expected 'build' or 'serve'" >&2
@@ -30,22 +26,17 @@ php maintenance/run.php install \
   MediaWiki \
   Admin
 
-# Fetch third-party extensions/skins before WikvenSettings is wired in, so they
-# are on disk when the build boot loads them (and no "not bundled" warnings fire
-# while they are still being fetched).
+# Fetch third-party extensions/skins before WikvenSettings loads, so they're on disk in time.
 php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/fetchExtensions.php
 
-# Wire in WikvenSettings, but only once: a persistent/mounted install tree would
-# otherwise collect a duplicate require_once on every run.
+# Wire in WikvenSettings once; a persistent install tree would otherwise duplicate require_once.
 grep -qF "require_once 'WikvenSettings.php';" LocalSettings.php \
   || echo 'require_once '\''WikvenSettings.php'\'';' >> LocalSettings.php
 
 php maintenance/run.php /var/www/html/extensions/Wikven/maintenance/build.php
 rm -rf "$WIKVEN_WORKDIR/dist/history/"
 
-# The build runs as root, so its output is root-owned on the host bind mount.
-# Hand it back to whoever owns the mounted output directory (the invoking user),
-# so they can read, edit, and clean dist/ without sudo.
+# The build runs as root; hand dist/ back to the mount owner so they can edit it without sudo.
 if [ -d "$WIKVEN_WORKDIR/dist" ]; then
   chown -R "$(stat -c '%u:%g' "$WIKVEN_WORKDIR/dist")" "$WIKVEN_WORKDIR/dist"
 fi

--- a/caddy/wikven.go
+++ b/caddy/wikven.go
@@ -1,8 +1,4 @@
-// Package wikvencaddy registers "build" and "serve" subcommands on the wikven
-// binary, so the static site can be built with `./wikven build` and previewed
-// with `./wikven serve` instead of the longer underlying invocations. Both
-// re-invoke this same binary: build through the embedded php-cli, serve through
-// Caddy's built-in file-server.
+// Package wikvencaddy registers the "build" and "serve" subcommands on the wikven binary.
 package wikvencaddy
 
 import (
@@ -47,8 +43,7 @@ func init() {
 	})
 }
 
-// reexec runs this same binary with the given arguments, wiring through the
-// standard streams and the current environment.
+// reexec runs this same binary with the given args, wiring stdio and the current environment.
 func reexec(args ...string) (int, error) {
 	self, err := os.Executable()
 	if err != nil {

--- a/includes/AssetLocalizer.php
+++ b/includes/AssetLocalizer.php
@@ -6,23 +6,9 @@ use MediaWiki\Request\FauxRequest;
 use MediaWiki\ResourceLoader\Context;
 use MediaWiki\ResourceLoader\ResourceLoader;
 
-/**
- * Rewrites image references inside dumped CSS and JS bundles to locally dumped
- * image files, so the static output never calls load.php or points at a path
- * that only exists inside a live MediaWiki install. Two reference forms are
- * handled:
- *
- *   - the ResourceLoader image endpoint: url(/load.php?...image=...)
- *   - direct skin/resource asset paths:  url(/skins/...x.svg), url(/resources/...)
- *
- * Both plain CSS and the JSON-escaped form embedded in combined-mode JS bundles
- * (url(\/load.php?a&image=b)) are handled.
- */
+/** Rewrites image url()s in dumped CSS/JS to local copies, avoiding load.php references. */
 class AssetLocalizer {
-	/**
-	 * Rewrite the image url()s in the given dumped CSS/JS files (absolute paths)
-	 * to point at image copies dumped into $dir.
-	 */
+	/** Rewrite image url()s in the given dumped CSS/JS files to point at copies in $dir. */
 	public static function localizeImages(
 		ResourceLoader $rl,
 		string $dir,
@@ -77,8 +63,7 @@ class AssetLocalizer {
 	}
 
 	/**
-	 * Dump a single ResourceLoader image-endpoint URL ($url, a decoded
-	 * /load.php?...image=... reference) to a local file.
+	 * Dump a decoded /load.php?...image=... reference ($url) to a local image file.
 	 *
 	 * @return string|null Relative url() target (./img-*.svg), or null if not an image.
 	 */
@@ -127,9 +112,7 @@ class AssetLocalizer {
 	}
 
 	/**
-	 * Copy a direct asset path ($path, an absolute web path with a leading slash
-	 * and no query, e.g. /skins/Vector/.../foo.svg) out of the MediaWiki install
-	 * into the output directory.
+	 * Copy a direct asset path ($path, absolute web path like /skins/.../foo.svg) into $dir.
 	 *
 	 * @return string|null Relative url() target, or null if the file is missing.
 	 */

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -14,9 +14,7 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 		$out->addModuleStyles('ext.Wikven.styles');
 		$out->addModules('ext.Wikven.pinnableState');
 
-		// The header search box has no working backend on a static site, so hide
-		// it, unless SifterSearch is installed to serve search from a static
-		// Pagefind bundle.
+		// No search backend on a static site; hide the box unless SifterSearch serves Pagefind.
 		if (!ExtensionRegistry::getInstance()->isLoaded('SifterSearch')) {
 			$out->addInlineStyle('#p-search { display: none; }');
 		}
@@ -27,13 +25,9 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 			$out->addJsConfigVars('wgWikvenMainSkin', $GLOBALS['wgWikvenMainSkin'] ?? '');
 		}
 
-		// Citizen's search is its own REST-backed command palette, which has no
-		// backend on the static export; hide its trigger there. SifterSearch does
-		// not wire Citizen, so there is no Pagefind-backed replacement. A live wiki
-		// (web entry) keeps Citizen's search working, so only hide it on the build.
+		// Citizen's REST search has no backend on the static build; hide it only on cli export.
 		if (MW_ENTRY_POINT === 'cli' && $skin->getSkinName() === 'citizen') {
-			// !important: the element also carries .citizen-dropdown, whose
-			// display:flex would otherwise win by cascade order.
+			// !important: .citizen-dropdown's display:flex would otherwise win by cascade order.
 			$out->addInlineStyle('.citizen-search { display: none !important; }');
 		}
 	}
@@ -71,11 +65,7 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 		}
 	}
 
-	/**
-	 * A display name for the host of the project URL, so the footer link is not
-	 * hardcoded to GitHub. Known forges are prettified; any other host is shown
-	 * as-is, and a URL with no host yields null (the caller drops the host name).
-	 */
+	/** Display name for the project URL's host; forges prettified, others as-is, no host null. */
 	private function repoHostName(string $url): ?string {
 		$host = parse_url($url, PHP_URL_HOST);
 		if (!is_string($host) || $host === '') {
@@ -93,11 +83,7 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 		return $known[$host] ?? $host;
 	}
 
-	/**
-	 * A footer <select> linking to the other enabled skins' copies of the current
-	 * page. The ext.Wikven.skinSwitcher module wires the navigation; without it
-	 * the control is an inert list of the available skins.
-	 */
+	/** Footer <select> linking to other skins' copies; ext.Wikven.skinSwitcher wires navigation. */
 	private function skinSwitcher(Skin $skin, array $skins, string $current): string {
 		$displayNames = MediaWikiServices::getInstance()->getSkinFactory()->getInstalledSkins();
 		$options = '';

--- a/includes/Hooks/Hider.php
+++ b/includes/Hooks/Hider.php
@@ -16,17 +16,12 @@ class Hider implements
 
 	/** @inheritDoc */
 	public function onSidebarBeforeOutput($skin, &$sidebar): void {
-		// The toolbox is all server/special-page tools that a static export cannot
-		// serve. The search portlet is dropped too, unless SifterSearch provides
-		// static search and a skin renders its box here (rather than in the header,
-		// like Vector): then keep it so SifterSearch has a box to wire, matching how
-		// the header search box is kept (see Adder and rewriteScripts).
+		// Drop server tools a static export can't serve; keep SEARCH only if SifterSearch wires a box.
 		$keys = ['TOOLBOX'];
 		if (!ExtensionRegistry::getInstance()->isLoaded('SifterSearch')) {
 			$keys[] = 'SEARCH';
 		}
-		// Empty rather than unset: some skins (e.g. Minerva) read these keys and
-		// require them to stay arrays.
+		// Empty rather than unset: some skins (e.g. Minerva) require these keys to stay arrays.
 		foreach ($keys as $key) {
 			if (isset($sidebar[$key])) {
 				$sidebar[$key] = [];
@@ -36,20 +31,14 @@ class Hider implements
 
 	/** @inheritDoc */
 	public function onSkinTemplateNavigation__Universal($sktemplate, &$links): void {
-		// Hide the personal tools (login, talk, preferences, etc.); this replaces the
-		// removed PersonalUrls hook. Empty the groups rather than unset them: some
-		// skins (e.g. Minerva) read these keys and require them to stay arrays.
+		// Hide personal tools (login, talk, prefs); empty groups so skins like Minerva keep them.
 		foreach (['user-menu', 'user-page', 'user-interface-preferences', 'notifications'] as $key) {
 			if (isset($links[$key])) {
 				$links[$key] = [];
 			}
 		}
 
-		// The edit and history tabs only make sense when they point at the
-		// external URLs configured via $wgWikvenEditUrl / $wgWikvenHistoryUrl, and
-		// at a page with a source file behind them. A generated page (e.g.
-		// Version) has none, so its links would 404; without the URLs, GetLocalURL
-		// falls back to a self-link (./Page.html). Drop the tabs in either case.
+		// Edit/history tabs need configured external URLs and a source file; else they 404 or self-link.
 		global $wgWikvenEditUrl, $wgWikvenHistoryUrl;
 		$title = $sktemplate->getTitle();
 		$hasSource = $title && SourceFile::exists($title->getPrefixedText());

--- a/includes/Hooks/Main.php
+++ b/includes/Hooks/Main.php
@@ -38,9 +38,7 @@ class Main implements
 			return;
 		}
 
-		// Images come from a foreign repo (Wikimedia Commons via InstantCommons),
-		// so the static export has no local File: page to link to. Point clicks at
-		// the file's real description page on Commons instead of a dead ./File:*.html.
+		// Foreign-repo files (Commons via InstantCommons) have no local File: page; link to Commons.
 		if ($title->getNamespace() === NS_FILE) {
 			$file = MediaWikiServices::getInstance()->getRepoGroup()->findFile($title);
 			if ($file && !$file->isLocal()) {
@@ -51,11 +49,9 @@ class Main implements
 
 		global $wgWikvenEditUrl, $wgWikvenHistoryUrl;
 		$name = Title::makeName($title->getNamespace(), $title->getDBkey());
-		// Parse the query into name=>value pairs rather than substring-matching
-		// "action=", which would also fire on e.g. "veaction=edit".
+		// Parse query to name=>value; substring-matching "action=" would also match "veaction=edit".
 		$action = wfCgiToArray($query)['action'] ?? null;
-		// For edit/history, $1 is the page's source filename, so the link lands
-		// on the file to edit rather than the rendered page.
+		// For edit/history, $1 is the source filename so the link targets the editable file.
 		if ($action === 'edit' && $wgWikvenEditUrl) {
 			$url = str_replace('$1', SourceFile::titleToParam($title->getPrefixedText()), $wgWikvenEditUrl);
 		} elseif ($action === 'history' && $wgWikvenHistoryUrl) {
@@ -66,17 +62,14 @@ class Main implements
 	}
 
 	/**
-	 * Add a "View source" tab linking to the page's source file in the repository
-	 * ($wgWikvenViewSourceUrl, with $1 the source file name), the read-only
-	 * counterpart of the Edit tab. Skipped when the URL is not configured.
+	 * Add a "View source" tab linking to the page's source file (read-only counterpart of Edit).
 	 *
 	 * @inheritDoc
 	 */
 	public function onSkinTemplateNavigation__Universal($sktemplate, &$links): void {
 		global $wgWikvenViewSourceUrl;
 		$title = $sktemplate->getTitle();
-		// A generated page (e.g. Version) has no source file, so its source link
-		// would 404 in the repository; skip it as if the URL were unconfigured.
+		// A generated page (e.g. Version) has no source file; skip rather than emit a 404 link.
 		if (
 			!$wgWikvenViewSourceUrl
 			|| !$title
@@ -130,9 +123,7 @@ class Main implements
 			}
 		}
 
-		// Non-main skins render duplicate copies of every page under dist/<skin>/.
-		// Point their canonical link at the main skin's copy one directory up (the
-		// dist root) so crawlers dedupe to it.
+		// Non-main skins duplicate every page; point canonical at the main skin's copy one dir up.
 		$mainSkin = $GLOBALS['wgWikvenMainSkin'] ?? null;
 		$title = $out->getTitle();
 		if (

--- a/includes/SiteConfig.php
+++ b/includes/SiteConfig.php
@@ -2,19 +2,12 @@
 
 namespace MediaWiki\Extension\Wikven;
 
-/**
- * Helpers for a site's configuration file (any of the accepted .wikven.yaml /
- * .wikven.yml / .wikven.json names, dotted or plain; see CONFIG_FILENAMES).
- */
+/** Helpers for a site's configuration file (accepted .wikven.* names; see CONFIG_FILENAMES). */
 class SiteConfig {
 	/** Top-level keys the settings format recognises. */
 	private const TOP_LEVEL_KEYS = ['config', 'extensions', 'skins'];
 
-	/**
-	 * The site-config file names wikven accepts in a source directory, in
-	 * precedence order (the first one present wins). Dotted before plain, YAML
-	 * before JSON, and the established ".yaml" spelling before ".yml".
-	 */
+	/** Site-config file names wikven accepts, in precedence order (first present wins). */
 	public const CONFIG_FILENAMES = [
 		'.wikven.yaml',
 		'.wikven.yml',
@@ -25,9 +18,7 @@ class SiteConfig {
 	];
 
 	/**
-	 * Find the site config file in a source directory. Returns the path of the
-	 * highest-precedence accepted name present (or null when none is), together
-	 * with any lower-precedence names also present, which are ignored.
+	 * Find the site config file; return highest-precedence present name and ignored lower ones.
 	 *
 	 * @param string $srcDir The source directory to look in.
 	 * @return array{path: ?string, ignored: string[]}
@@ -47,13 +38,7 @@ class SiteConfig {
 	}
 
 	/**
-	 * Lint decoded site-config contents, returning a warning for each mistake the
-	 * settings system would otherwise drop silently: an unknown top-level key, a
-	 * wrong-typed config/extensions/skins, a misspelled Wikven variable (which
-	 * would set a global nothing reads), or a Wikven value of the wrong shape (a
-	 * URL template missing its $1 placeholder, a non-map logos/repositories).
-	 * Messages are returned rather than logged so the check stays pure and
-	 * unit-testable.
+	 * Lint decoded site-config contents, returning a warning per silently-dropped mistake.
 	 *
 	 * @param mixed $data Decoded .wikven.yaml/.json contents.
 	 * @param string[] $knownConfig Canonical Wikven config variable names, from extension.json.
@@ -85,9 +70,7 @@ class SiteConfig {
 			}
 		}
 
-		// Value-shape checks for the Wikven keys whose shape matters, so a wrong
-		// type or a URL template missing its $1 placeholder is caught here rather
-		// than silently producing broken links or being dropped.
+		// Catch wrong types or URL templates missing the $1 placeholder before they break links.
 		foreach (['WikvenEditUrl', 'WikvenHistoryUrl', 'WikvenViewSourceUrl'] as $urlKey) {
 			$value = $config[$urlKey] ?? '';
 			if ($value !== '' && ( !is_string($value) || !str_contains($value, '$1') )) {

--- a/includes/SourceFile.php
+++ b/includes/SourceFile.php
@@ -5,46 +5,16 @@ namespace MediaWiki\Extension\Wikven;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\SlotRecord;
 
-/**
- * The mapping between a source file and the wiki page it imports as.
- *
- * A page's content model is derived from its title, so any title MediaWiki
- * gives a non-wikitext model — MediaWiki:Common.css (sanitized-css),
- * MediaWiki:Common.js (javascript), a .json config page, a Module: Scribunto
- * page, a Template /styles.css page, or whatever a loaded extension registers
- * (mustache, ...) — *is* the page under its own name. The file keeps that name,
- * so editors highlight and lint it natively and the title round-trips exactly.
- * Every other page has no content model of its own, so it gets a ".wikitext"
- * marker that both flags the file as a page to import and is stripped to recover
- * the title. Files MediaWiki would treat as plain wikitext under their own name
- * (logo.png, Bakery oven.jpg, .wikven.yaml) are assets, not pages.
- *
- * The non-wikitext set is never hard-coded here: it is whatever the running
- * wiki's content-model registry and ContentHandlerDefaultModelFor hooks resolve,
- * so loading an extension that adds a model is enough to make its files import.
- *
- * filenameToTitle() and titleToFilename() are inverses, so the same convention
- * drives both the importer (file -> page) and the edit/history links the static
- * export points back at the source (page -> file).
- */
+/** Maps a source file to the wiki page it imports as, and back. */
 class SourceFile {
 	private const MARKER = 'wikitext';
 
-	/**
-	 * Whether a file under the source directory (given by its path relative to
-	 * it) is a page to import, as opposed to an asset like an image or the
-	 * .wikven.yaml config.
-	 */
+	/** Whether a relative source path is a page to import, not an asset. */
 	public static function isPageFile(string $relativePath): bool {
 		return str_ends_with($relativePath, '.' . self::MARKER) || self::titleHasOwnContentModel($relativePath);
 	}
 
-	/**
-	 * Map a source path (relative to the source directory) to its page title:
-	 * drop the ".wikitext" marker if present, otherwise keep the path verbatim
-	 * because the title carries its own content model. A nested file becomes a
-	 * subpage, so "Template:Foo/styles.css" imports as "Template:Foo/styles.css".
-	 */
+	/** Source path -> page title: drop the ".wikitext" marker, else keep verbatim. */
 	public static function filenameToTitle(string $relativePath): string {
 		$suffix = '.' . self::MARKER;
 		if (str_ends_with($relativePath, $suffix)) {
@@ -53,11 +23,7 @@ class SourceFile {
 		return $relativePath;
 	}
 
-	/**
-	 * Map a page title back to its source path (the inverse of
-	 * filenameToTitle()): keep the title verbatim when it carries its own
-	 * content model, otherwise append the ".wikitext" marker.
-	 */
+	/** Page title -> source path: append ".wikitext" unless the title has its own content model. */
 	public static function titleToFilename(string $title): string {
 		if (self::titleHasOwnContentModel($title)) {
 			return $title;
@@ -65,24 +31,12 @@ class SourceFile {
 		return $title . '.' . self::MARKER;
 	}
 
-	/**
-	 * The source file name of a page, percent-encoded for use as the $1 in the
-	 * edit/history/view-source URL templates. Built from the prefixed title text
-	 * (spaces, not the DB key's underscores) so it matches the on-disk file name,
-	 * then encoded so characters legal in a title but unsafe in a URL path
-	 * (spaces, '#', '?', '%', non-ASCII) cannot break or truncate the link. The
-	 * subpage separator '/' and the namespace separator ':' are kept readable.
-	 */
+	/** Page's source file name, percent-encoded for the $1 in URL templates ('/' and ':' kept). */
 	public static function titleToParam(string $titleText): string {
 		return strtr(rawurlencode(self::titleToFilename($titleText)), ['%2F' => '/', '%3A' => ':']);
 	}
 
-	/**
-	 * Whether the page with the given prefixed title text was imported from a
-	 * source file, as opposed to generated during the build (like the Version
-	 * page). The edit/history/view-source links point at that source file, so
-	 * there is nothing for them to point at when it does not exist.
-	 */
+	/** Whether the page was imported from a source file, not generated during the build. */
 	public static function exists(string $titleText): bool {
 		global $wgWikvenSourceDirectory;
 		if ((string)$wgWikvenSourceDirectory === '') {
@@ -91,12 +45,7 @@ class SourceFile {
 		return is_file(rtrim($wgWikvenSourceDirectory, '/') . '/' . self::titleToFilename($titleText));
 	}
 
-	/**
-	 * Whether MediaWiki resolves a non-wikitext default content model for the
-	 * given title text — i.e. the title (via its extension or namespace) already
-	 * determines the content, so no ".wikitext" marker is needed. Driven by the
-	 * live content-model registry, so it tracks whatever extensions are loaded.
-	 */
+	/** Whether the title resolves a non-wikitext default content model (so no marker is needed). */
 	private static function titleHasOwnContentModel(string $titleText): bool {
 		$services = MediaWikiServices::getInstance();
 		$title = $services->getTitleFactory()->newFromText($titleText);

--- a/includes/WikvenSettings.php
+++ b/includes/WikvenSettings.php
@@ -2,15 +2,9 @@
 
 wfLoadExtension('Wikven');
 
-// Build mechanics. The user-overridable MediaWiki defaults live in default.yml;
-// only the static-export internals that are not plain config stay here.
+// Static-export build internals; user-overridable defaults live in default.yml.
 
-// All filesystem locations derive from one working directory so the same build
-// works in the Docker image (where /workspace is mounted) and in a standalone
-// binary (where it points at a writable host directory). Layout:
-//   $WIKVEN_WORKDIR/src    input (read-only)
-//   $WIKVEN_WORKDIR/dist   output (the rendered file cache)
-//   $WIKVEN_WORKDIR/.cache ephemeral state (uploads, l10n + object cache, tmp)
+// Paths derive from one workdir (src input, dist output, .cache ephemeral state).
 $wikvenWorkEnv = getenv('WIKVEN_WORKDIR');
 $wikvenWork = $wikvenWorkEnv !== false && $wikvenWorkEnv !== '' ? $wikvenWorkEnv : '/workspace';
 $wikvenSrc = "$wikvenWork/src";
@@ -24,14 +18,10 @@ $wgFileCacheDirectory = $wikvenDist;
 $wgWikvenSourceDirectory = $wikvenSrc;
 $wgWikvenHtmlDirectory = $wikvenDist;
 
-// Let pages opt out of indexing with __NOINDEX__ in any namespace (by default
-// content namespaces are exempt from user robot control).
+// Let pages opt out of indexing with __NOINDEX__ in any namespace.
 $wgExemptFromUserRobotsControl = [];
 
-// Standalone-binary mode (WIKVEN_WORKDIR set): keep every ephemeral write out of
-// the install dir, which in the embedded binary is an extracted, throwaway tree.
-// In the Docker image WIKVEN_WORKDIR is unset, the install dir is writable, and
-// MediaWiki's defaults are left untouched (no behavior change).
+// Standalone-binary mode (WIKVEN_WORKDIR set): keep ephemeral writes out of the install dir.
 if ($wikvenWorkEnv !== false && $wikvenWorkEnv !== '') {
 	$wgUploadDirectory = "$wikvenCache/uploads";
 	$wgCacheDirectory = "$wikvenCache/mw";
@@ -43,8 +33,7 @@ if ($wikvenWorkEnv !== false && $wikvenWorkEnv !== '') {
 	}
 }
 
-// Ship a small built-in favicon so browsers do not 404 on /favicon.ico.
-// Overridable from .wikven.yaml via "config": { "Favicon": "..." }.
+// Built-in favicon so browsers do not 404; overridable via config.Favicon.
 $wgFavicon = 'data:image/svg+xml,'
 . rawurlencode(
 	'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">'
@@ -55,16 +44,7 @@ $wgFavicon = 'data:image/svg+xml,'
 
 unset($wgFooterIcons['poweredby']);
 
-// Image backend, detected at run time so the build uses whatever the host has.
-// Raster thumbnails (png/jpg/gif/webp) go through ImageMagick when its `convert`
-// (or `magick`) is on PATH, otherwise the GD extension. SVG goes through
-// rsvg-convert when present, otherwise it is served inline as sanitized native
-// SVG. SVG is deliberately never routed through ImageMagick, whose built-in
-// 'ImageMagick' converter calls the `convert` binary that does not exist on
-// ImageMagick-7-only hosts. This runs before the config load below, so an
-// explicit value in .wikven.yaml still wins; default.yml does not set the
-// backend. In the Docker image both tools are present, so this reproduces the
-// previous ImageMagick + rsvg configuration exactly.
+// Detect image backend at run time; SVG never via ImageMagick (IM7 lacks `convert`).
 $wikvenFindExe = static function (array $names) {
 	$path = getenv('PATH') ?: '/usr/local/bin:/usr/bin:/bin';
 	foreach ($names as $name) {
@@ -97,24 +77,14 @@ if ($wikvenConvert === null || $wikvenRsvg === null) {
 	);
 }
 
-// Configuration: wikven's defaults (default.yml) and then the site's own
-// .wikven.yaml (or .wikven.json) on top, loaded through MediaWiki's own settings
-// system ($wgSettings, available here because LocalSettings.php runs inside it).
-// The "config" map (variables without the "wg" prefix) is fed to $wgSettings so
-// keys merge per their declared strategy and can be schema-validated; the
-// "extensions" and "skins" lists are collected here and loaded leniently below,
-// because the settings loader fatals on a name it cannot find whereas wikven
-// skips an unbundled one. The site file may be any accepted name (.wikven.yaml,
-// .wikven.yml, .wikven.json, or the plain forms; YAML is a superset of JSON).
+// Load config: default.yml then the site file via $wgSettings; ext/skin lists loaded leniently.
 global $wgSettings;
 
-// Wikven's own config variables, used to flag a misspelled one (which would set
-// a global nothing reads); the canonical names come from extension.json.
+// Known config names from extension.json, used to flag misspelled keys.
 $wikvenManifest = json_decode(file_get_contents("$IP/extensions/Wikven/extension.json"), true);
 $wikvenKnownConfig = array_keys($wikvenManifest['config'] ?? []);
 
-// This runs while LocalSettings.php is read, before the extension registry has
-// activated Wikven's autoloader, so load the (dependency-free) helper directly.
+// Autoloader not active yet at LocalSettings time; load the helper directly.
 require_once "$IP/extensions/Wikven/includes/SiteConfig.php";
 
 // Pick the highest-precedence config name present; warn about any others.
@@ -127,9 +97,7 @@ if ($wikvenSiteFile !== null && $wikvenLocated['ignored'] !== []) {
 	);
 }
 
-// The defaults, then the site file on top. For each, hand its "config" map to
-// $wgSettings (so keys merge per their declared strategy) and collect its
-// extension/skin names for the lenient loading below.
+// Defaults then site file: feed each "config" map to $wgSettings, collect ext/skin names.
 $config = ['extensions' => [], 'skins' => []];
 $wikvenYaml = new MediaWiki\Settings\Source\Format\YamlFormat();
 $wikvenYamlData = $wikvenYaml->decode(file_get_contents("$IP/extensions/Wikven/default.yml"));
@@ -156,19 +124,14 @@ foreach ([$wikvenYamlData, $wikvenSiteData] as $wikvenData) {
 	$config['skins'] = array_merge($config['skins'], (array)( $wikvenData['skins'] ?? [] ));
 }
 
-// Push the merged config into globals so the logo handling below reads the final
-// values.
+// Push merged config into globals so the logo handling below reads final values.
 $wgSettings->apply();
 
-// Load each extension/skin at most once even if it appears in both the defaults
-// and the site file (or twice in one list).
+// Dedupe so each extension/skin loads at most once.
 $config['extensions'] = array_values(array_unique(array_filter($config['extensions'], 'is_string'), SORT_STRING));
 $config['skins'] = array_values(array_unique(array_filter($config['skins'], 'is_string'), SORT_STRING));
 
-// Skins. Register each named skin and collect its canonical name (e.g. 'minerva'
-// can differ from the directory 'MinervaNeue', so read it from skin.json). Only
-// skins bundled in this image can be enabled; an unknown name is skipped with a
-// warning instead of aborting the whole build.
+// Register each bundled skin; canonical name (may differ from dir) read from skin.json.
 $wgWikvenSkins = [];
 foreach ($config['skins'] ?? [] as $skin) {
 	if (!is_string($skin)) {
@@ -188,31 +151,23 @@ foreach ($config['skins'] ?? [] as $skin) {
 }
 $wgWikvenSkins = array_values(array_unique($wgWikvenSkins));
 
-// The first listed skin is the site default (set unconditionally: the installer
-// has already written $wgDefaultSkin, so a !isset guard would never fire).
+// First listed skin is the site default.
 $wgWikvenMainSkin = $wgWikvenSkins[0] ?? $wgDefaultSkin;
 $wgDefaultSkin = $wgWikvenMainSkin;
 
-// Per-skin build pass. The build renders each skin in its own MediaWiki boot,
-// selected by WIKVEN_BUILD_SKIN: the main skin into the dist root, every other
-// skin into a dist/<skin>/ subdirectory. Unset (a normal single-skin build) is a
-// no-op, so the default output is unchanged.
+// Per-skin build pass: WIKVEN_BUILD_SKIN renders main skin to dist root, others to dist/<skin>/.
 $wikvenBuildSkin = getenv('WIKVEN_BUILD_SKIN');
 if ($wikvenBuildSkin !== false && in_array($wikvenBuildSkin, $wgWikvenSkins, true)) {
 	$wgDefaultSkin = $wikvenBuildSkin;
 	if ($wikvenBuildSkin !== $wgWikvenMainSkin) {
 		$wgWikvenHtmlDirectory = "$wikvenDist/$wikvenBuildSkin";
 		$wgFileCacheDirectory = $wgWikvenHtmlDirectory;
-		// Non-main skins are duplicate copies of the main skin's pages, so keep
-		// them out of search indexes (only the main skin at the dist root is
-		// indexed). Read at render time, so RebuildFileCache emits it.
+		// Non-main skins duplicate the main skin's pages; keep them out of search indexes.
 		$wgDefaultRobotPolicy = 'noindex,follow';
 	}
 }
 
-// Extensions. Only extensions bundled in this image can be enabled; a name that
-// is not installed (a typo, or a third-party extension that is not yet
-// supported) is skipped with a warning instead of aborting the whole build.
+// Load each bundled extension; an unknown name is skipped with a warning.
 foreach ($config['extensions'] ?? [] as $extension) {
 	if (!is_string($extension)) {
 		continue;
@@ -224,31 +179,16 @@ foreach ($config['extensions'] ?? [] as $extension) {
 	}
 }
 
-// Logos: WikvenLogos mirrors MediaWiki's $wgLogos, except each source is the name
-// of an image file in the source directory rather than a URL. Those files are
-// uploaded into the File: namespace at build time like any other source image, so
-// each one already has a URL; we point $wgLogos at it. The upload path is
-// predictable because uploads are stored flat (HashedUploadDirectory: false in
-// default.yml), so the URL can be built here, at config time, before the file is
-// actually uploaded later in the build. The static export then localizes that URL
-// to a single shared file alongside the HTML (storeImages.php), so the logo is not
-// inlined into every page. A value is either a file name, or (like
-// $wgLogos['wordmark'] and ['tagline']) a map with a "src" file name plus extra
-// keys such as width and height.
+// WikvenLogos mirrors $wgLogos but each src is a source-dir file name; resolve to its upload URL.
 if (!empty($wgWikvenLogos) && is_array($wgWikvenLogos)) {
-	// Map a source file name to the URL its upload will have. MediaWiki turns the
-	// file name into a File: title (spaces become underscores, and the first letter
-	// is capitalized unless $wgCapitalLinks is off, as Wikven's default keeps it),
-	// then, with flat storage, serves it from $wgUploadPath/<title>.
+	// Map a source file name to the flat-storage URL its upload will have.
 	$wikvenLogoUrl = static function ($name) use ($wikvenSrc) {
 		global $wgUploadPath, $wgScriptPath, $wgCapitalLinks;
 		if (!is_file("$wikvenSrc/" . $name)) {
 			error_log("Wikven: logo file '$name' not found in the source directory");
 			return null;
 		}
-		// $wgUploadPath is still its false default this early (MediaWiki resolves it
-		// to "$wgScriptPath/images" later, in Setup.php); resolve it the same way so
-		// the URL matches what the upload, and storeImages.php, will use.
+		// $wgUploadPath is false this early; resolve to $wgScriptPath/images as Setup.php does.
 		$uploadPath =
 			$wgUploadPath !== false && (string)$wgUploadPath !== ''
 				? $wgUploadPath

--- a/mago.toml
+++ b/mago.toml
@@ -1,11 +1,6 @@
-# A mago configuration that approximates the MediaWiki coding style
-# (mediawiki/mediawiki-codesniffer) as closely as mago allows.
-# Derived from https://github.com/chaotic-ground/mago-mediawiki-style,
-# which tracks how far this configuration is from a zero diff against
-# MediaWiki core and lists the differences that cannot be configured away.
+# Approximates MediaWiki coding style; tracked at chaotic-ground/mago-mediawiki-style.
 
-# MediaWiki 1.45 (the base image, see Dockerfile) requires PHP 8.1+, so lint
-# against 8.1 as the floor even though the shipped binary runs a newer PHP.
+# MediaWiki 1.45 (base image) needs PHP 8.1+, so lint against 8.1 though the binary runs newer.
 php-version = "8.1"
 
 [source]

--- a/maintenance/build.php
+++ b/maintenance/build.php
@@ -19,21 +19,7 @@ $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 
 require_once "$IP/maintenance/Maintenance.php";
 
-/**
- * Build the whole static site.
- *
- * Run without WIKVEN_BUILD_SKIN this is the orchestrator: it populates the wiki
- * once (set the main page, import images and wikitext, run queued jobs) and then
- * renders each enabled skin, re-invoking itself with WIKVEN_BUILD_SKIN set so
- * every skin gets a fresh MediaWiki boot and never inherits another skin's
- * cached state.
- *
- * A per-skin pass (WIKVEN_BUILD_SKIN set) renders the already-imported content
- * into that skin's output directory: (re)build the file cache, dump styles and
- * scripts, rewrite them for the static host, store images locally, and give the
- * files readable names. The main skin lands in the dist root, others in
- * dist/<skin>/ (see WikvenSettings).
- */
+/** Build the static site: populate the wiki, then render each enabled skin in a fresh boot. */
 class Build extends Maintenance {
 	public function __construct() {
 		parent::__construct();
@@ -41,9 +27,7 @@ class Build extends Maintenance {
 	}
 
 	public function execute() {
-		// A per-skin pass (WIKVEN_BUILD_SKIN set) renders the imported content in
-		// one skin; the orchestrating run populates the wiki, then spawns a pass
-		// per enabled skin.
+		// WIKVEN_BUILD_SKIN set renders one skin; orchestrator populates then spawns a pass per skin.
 		if ((string)getenv('WIKVEN_BUILD_SKIN') !== '') {
 			$this->renderSkin();
 			return;
@@ -71,17 +55,11 @@ class Build extends Maintenance {
 		}
 	}
 
-	/**
-	 * Render one enabled skin in a fresh MediaWiki boot by re-invoking this script
-	 * with WIKVEN_BUILD_SKIN set. A fresh process gives the pass its own
-	 * $wgDefaultSkin and output directory without inheriting cached skin or
-	 * ResourceLoader state. Re-invocation mirrors however this process started:
-	 * plain php exposes PHP_BINARY, the embedded FrankenPHP binary leaves it empty
-	 * and is re-run as "<self> php-cli".
-	 */
+	/** Render one skin in a fresh boot by re-invoking this script with WIKVEN_BUILD_SKIN set. */
 	private function renderSkinPass(string $skin): void {
 		$self = PHP_BINARY;
 		$prefix = [$self];
+		// Embedded FrankenPHP leaves PHP_BINARY empty; re-run the binary itself as "<self> php-cli".
 		if ($self === '' || !is_executable($self)) {
 			$self = is_link('/proc/self/exe') ? ( readlink('/proc/self/exe') ?: '' ) : '';
 			$prefix = [$self, 'php-cli'];
@@ -90,8 +68,7 @@ class Build extends Maintenance {
 			$this->fatalError('Wikven: cannot locate the PHP executable to render skins');
 		}
 
-		// run.php is resolved relative to the install root (required by the binary's
-		// php-cli), so run the child from there; the script itself is absolute.
+		// run.php resolves relative to the install root (binary php-cli needs it), so chdir there.
 		chdir($GLOBALS['IP']);
 		$command = array_merge($prefix, ['maintenance/run.php', __FILE__]);
 
@@ -109,10 +86,7 @@ class Build extends Maintenance {
 		}
 	}
 
-	/**
-	 * Render the already-imported content in the skin selected by
-	 * WIKVEN_BUILD_SKIN, into that skin's output directory.
-	 */
+	/** Render the already-imported content in the WIKVEN_BUILD_SKIN skin's output directory. */
 	private function renderSkin(): void {
 		$ip = $GLOBALS['IP'];
 		$own = __DIR__;
@@ -128,22 +102,14 @@ class Build extends Maintenance {
 		$this->step(StoreImages::class, "$own/storeImages.php");
 		$this->step(Rename::class, "$own/rename.php");
 
-		// RebuildFileCache emits a per-page history/ tree the static host does not
-		// serve; drop it from this pass's output dir.
+		// RebuildFileCache emits a per-page history/ tree the static host won't serve; drop it.
 		$history = "$dir/history";
 		if (is_dir($history)) {
 			$this->removeDirectory($history);
 		}
 	}
 
-	/**
-	 * Empty the output directory so each build starts from a clean slate. The
-	 * dump/rewrite steps edit HTML in place and rename files, so output left by
-	 * an earlier run into a persistent (e.g. mounted) dist would otherwise
-	 * accumulate: orphaned renamed pages, doubly-rewritten image references, and
-	 * never-collected img-* files. The directory itself is kept (it may be a
-	 * mount point); only its contents are removed.
-	 */
+	/** Empty the output dir (kept, may be a mount) so in-place edits don't leave stale output. */
 	private function clearOutputDirectory(): void {
 		$dir = rtrim($GLOBALS['wgWikvenHtmlDirectory'], '/');
 		if ($dir === '' || !is_dir($dir)) {
@@ -162,9 +128,7 @@ class Build extends Maintenance {
 		}
 	}
 
-	/**
-	 * Recursively delete a directory and everything under it.
-	 */
+	/** Recursively delete a directory and everything under it. */
 	private function removeDirectory(string $dir): void {
 		$entries = new \RecursiveIteratorIterator(
 			new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
@@ -180,28 +144,19 @@ class Build extends Maintenance {
 		rmdir($dir);
 	}
 
-	/**
-	 * Run one build step as a child maintenance script, setting $options on the
-	 * child before it runs.
-	 */
+	/** Run one build step as a child maintenance script, applying $options first. */
 	private function step(string $class, string $file, array $options = []): void {
 		$child = $this->createChild($class, $file);
 		foreach ($options as $name => $value) {
 			$child->setOption($name, $value);
 		}
-		// A child that returns false reports failure (e.g. ImportWikitext could
-		// not import every page); abort rather than publish a site missing
-		// content with a success exit code. Steps that return null are unaffected.
+		// A child returning false signals failure (e.g. a page didn't import); abort the build.
 		if ($child->execute() === false) {
 			$this->fatalError("Wikven: $class reported failures; aborting the build.");
 		}
 	}
 
-	/**
-	 * Upload the image files in the source directory into the File: namespace,
-	 * so pages that embed them render with local thumbnails. Runs core's
-	 * importImages.php over the source directory; non-image files are ignored.
-	 */
+	/** Import source-dir images into the File: namespace so pages render with local thumbnails. */
 	private function importImages(string $file): void {
 		$child = $this->createChild(ImportImages::class, $file);
 		$child->setArg(0, rtrim($GLOBALS['wgWikvenSourceDirectory'], '/'));
@@ -210,11 +165,7 @@ class Build extends Maintenance {
 		$child->execute();
 	}
 
-	/**
-	 * Point the wiki's main page at the configured article ($wgWikvenMainPage,
-	 * "index" by default). The article itself is imported afterwards; see
-	 * assertMainPageExists().
-	 */
+	/** Point the wiki's main page at $wgWikvenMainPage (imported later; see assertMainPageExists). */
 	private function setMainPage(): void {
 		$title = Title::newFromText('MediaWiki:Mainpage');
 		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
@@ -226,18 +177,9 @@ class Build extends Maintenance {
 		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Set the main page'));
 	}
 
-	/**
-	 * Drop footer links whose target page was not imported: the about, privacy
-	 * and disclaimer links point at project pages a static export usually has
-	 * none of, so they would 404. A site that wants one just adds the page (e.g.
-	 * a "Wikven:Privacy policy" source file) and the link is kept. The footer
-	 * omits a link when its label message is disabled, so the missing ones get
-	 * their label message blanked to "-" (the SkinAddFooterLinks hook only adds,
-	 * it cannot remove these defaults). Runs after import so the pages exist.
-	 */
+	/** Hide about/privacy/disclaimer footer links with no imported target (blank label to "-"). */
 	private function dropDeadFooterPlaces(): void {
-		// Label message (the MediaWiki: page that controls whether the link
-		// shows) => page-name message (whose page the link points at).
+		// Label message (controls whether the link shows) => page-name message (the link's target).
 		$places = [
 			'Privacy' => 'privacypage',
 			'Aboutsite' => 'aboutpage',
@@ -257,14 +199,7 @@ class Build extends Maintenance {
 		}
 	}
 
-	/**
-	 * Drop the dead link from the category footer's "Categories" label, which
-	 * points at the Special:Categories page a static export has no copy of. The
-	 * skin renders the label as plain text when the "pagecategorieslink" message
-	 * resolves to no title, so blank that message. The category entries
-	 * themselves stay as they are: a category with an imported (or exported)
-	 * page keeps its link, one without it is a red link, like any other.
-	 */
+	/** Blank "pagecategorieslink" so the category label isn't a dead Special:Categories link. */
 	private function dropDeadCategoryLink(): void {
 		$user = User::newSystemUser(User::MAINTENANCE_SCRIPT_USER, ['steal' => true]);
 		$title = Title::newFromText('MediaWiki:Pagecategorieslink');
@@ -274,12 +209,7 @@ class Build extends Maintenance {
 		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Drop the dead category link'));
 	}
 
-	/**
-	 * Generate a Version page (mirroring Special:Version, which a static export
-	 * has no server to serve) listing the installed software, extensions and
-	 * skins. Skipped when $wgWikvenVersionPage is empty or the site already
-	 * provides a same-named page.
-	 */
+	/** Generate a Version page (static Special:Version) listing software, extensions and skins. */
 	private function setVersionPage(): void {
 		$name = $GLOBALS['wgWikvenVersionPage'] ?? 'Version';
 		if ($name === '') {
@@ -310,8 +240,7 @@ class Build extends Maintenance {
 		}
 		$text .= "|}\n\n";
 
-		// Split the registered components into extensions and skins (skins live
-		// under skins/), each in its own section as Special:Version does.
+		// Split components into extensions and skins (skins live under skins/), each in its own section.
 		$extensions = [];
 		$skins = [];
 		foreach (ExtensionRegistry::getInstance()->getAllThings() as $thingName => $credits) {
@@ -331,18 +260,12 @@ class Build extends Maintenance {
 		$updater->saveRevision(CommentStoreComment::newUnsavedComment('Generate the version page'));
 	}
 
-	/**
-	 * A message in the wiki's content language, for the generated version page
-	 * (which is content, not interface chrome, so it follows the site language).
-	 */
+	/** A message in the wiki's content language (the version page is content, not UI chrome). */
 	private function contentMsg(string $key): string {
 		return wfMessage($key)->inContentLanguage()->text();
 	}
 
-	/**
-	 * A wikitext table of installed components (extensions or skins) with their
-	 * versions and project links, under the given section/name-column messages.
-	 */
+	/** A wikitext table of components with versions and project links, under the given messages. */
 	private function componentTable(string $headingKey, string $nameColKey, array $things): string {
 		if (!$things) {
 			return '';
@@ -364,11 +287,7 @@ class Build extends Maintenance {
 		return $text;
 	}
 
-	/**
-	 * Fail the build if the configured main page was not imported. Without this
-	 * the main page points at a non-existent article, so the static host serves
-	 * no page at the site root while the build otherwise reports success.
-	 */
+	/** Fail the build if the configured main page wasn't imported (else the site root 404s). */
 	private function assertMainPageExists(): void {
 		$name = $GLOBALS['wgWikvenMainPage'];
 		$title = Title::newFromText($name);

--- a/maintenance/buildScripts.php
+++ b/maintenance/buildScripts.php
@@ -16,22 +16,7 @@ $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 
 require_once "$IP/maintenance/Maintenance.php";
 
-/**
- * Dump the JavaScript needed by the generated pages into two static files so
- * the skin's JS runs without a load.php server:
- *
- *   startup-static.js  the startup module (mw.loader + the register manifest),
- *                      with its trailing auto-load call removed so it does not
- *                      try to fetch the base modules over the network.
- *   modules-static.js  the full dependency closure of the page modules dumped
- *                      in combined mode, so every module is wrapped in a
- *                      self-executing mw.loader.impl() call.
- *
- * This is the JS analogue of buildStyles.php. Unlike CSS, an only=scripts dump
- * is inert (it force-marks modules 'ready', which skips execution), so the
- * closure must be dumped in combined mode and the base modules (jquery,
- * mediawiki.base) must be included explicitly.
- */
+/** Dump page JS (startup + module closure) to static files so the skin runs without load.php. */
 class BuildScripts extends Maintenance {
 	/** Module groups that are never emitted statically (mirrors Main/buildStyles). */
 	private const SKIP_GROUPS = ['noscript', 'private', 'user'];
@@ -54,28 +39,17 @@ class BuildScripts extends Maintenance {
 		}
 
 		$rl = MediaWikiServices::getInstance()->getResourceLoader();
-		// Gadgets registers its modules into the ResourceLoader at boot, before the
-		// single build process has imported the gadget definitions, so the modules
-		// are missing here. Re-register them from the (now populated) gadget repo.
+		// Gadgets registers modules at boot, before this build imported defs; re-register them here.
 		$this->registerGadgetModules($rl);
 		MediaWikiServices::getInstance()->getDBLoadBalancerFactory()->disableChronologyProtection();
 
 		// 1. Discover the modules the rendered pages actually queue.
 		$seeds = $this->collectPageModules($htmlDir);
-		// The site module (MediaWiki:Common.js plus the skin's JS) is pulled in by
-		// the startup module on a live wiki, so it never appears in a page's module
-		// queue. Seed it explicitly so that site JS runs on the static pages too.
+		// Seed 'site' (Common.js + skin JS); startup pulls it live so it is never in a page queue.
 		$seeds[] = 'site';
-		// Likewise the gadgets enabled for every reader: the Gadgets hook adds them
-		// at request time, which the static render does not reproduce, so seed them
-		// so default gadgets are bundled too.
+		// Seed default-on gadgets; the Gadgets hook adds them per-request, not in static render.
 		$seeds = array_merge($seeds, $this->defaultGadgetModules());
-		// SifterSearch serves search from a static Pagefind bundle, so the native
-		// search module can run offline once it is in the bundle. It is loaded
-		// lazily on search-box focus and so never appears in a page's module queue;
-		// seed the search module mediawiki.page.ready will load (after the
-		// SkinPageReadyConfig hook, which SifterSearch rewrites to its own
-		// Pagefind-backed module) so its closure (codex/vue) is bundled too.
+		// Seed the lazy search module (loaded on focus, never in page queue) so its closure bundles.
 		if (ExtensionRegistry::getInstance()->isLoaded('SifterSearch')) {
 			$searchModule = $this->resolveSearchModule($rl, $wgLanguageCode, $wgDefaultSkin);
 			if ($searchModule !== null && $rl->isModuleRegistered($searchModule)) {
@@ -85,8 +59,7 @@ class BuildScripts extends Maintenance {
 		// 2. Expand to the full dependency closure, plus the implicit base modules.
 		$closure = $this->resolveClosure($rl, $seeds, $wgLanguageCode, $wgDefaultSkin);
 
-		// 3. Dump startup and neutralise its auto-load of RLPAGEMODULES (which would
-		//    otherwise fetch the base modules from load.php and 404 on a static host).
+		// 3. Dump startup; strip its RLPAGEMODULES auto-load (would 404 fetching base from load.php).
 		$startup = $this->dump($rl, ['startup'], $wgLanguageCode, $wgDefaultSkin, 'scripts', ['raw' => '1']);
 		$startup = str_replace('mw.loader.load(window.RLPAGEMODULES||[]);', '', $startup);
 		file_put_contents("$outDir/startup-static.js", $startup, LOCK_EX);
@@ -95,8 +68,7 @@ class BuildScripts extends Maintenance {
 		$bundle = $this->dump($rl, $closure, $wgLanguageCode, $wgDefaultSkin, null, []);
 		file_put_contents("$outDir/modules-static.js", $bundle, LOCK_EX);
 
-		// The combined bundle embeds icon-module CSS that still points at the
-		// load.php image endpoint; localize those references to local files too.
+		// Combined bundle embeds icon CSS pointing at load.php images; localize them to local files.
 		AssetLocalizer::localizeImages(
 			$rl,
 			$outDir,
@@ -108,10 +80,7 @@ class BuildScripts extends Maintenance {
 		$this->output('Wrote startup-static.js and modules-static.js (' . count($closure) . " modules)\n");
 	}
 
-	/**
-	 * Register every gadget's ResourceLoader module on the given loader, mirroring
-	 * the Gadgets extension's own registration. No-op without the extension.
-	 */
+	/** Register each gadget's RL module, mirroring the Gadgets extension. No-op if absent. */
 	private function registerGadgetModules(ResourceLoader $rl): void {
 		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
 		if (!class_exists($repoClass)) {
@@ -130,11 +99,7 @@ class BuildScripts extends Maintenance {
 		}
 	}
 
-	/**
-	 * @return string[] Module names of the gadgets enabled for every reader (so
-	 *   they can be bundled like the page's own modules), or an empty array when
-	 *   the Gadgets extension is not loaded.
-	 */
+	/** @return string[] Module names of default-on gadgets, or [] without the Gadgets extension. */
 	private function defaultGadgetModules(): array {
 		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
 		if (!class_exists($repoClass)) {
@@ -153,9 +118,7 @@ class BuildScripts extends Maintenance {
 		return $modules;
 	}
 
-	/**
-	 * @return string[] The union of the RLPAGEMODULES lists across all pages.
-	 */
+	/** @return string[] The union of the RLPAGEMODULES lists across all pages. */
 	private function collectPageModules(string $htmlDir): array {
 		$modules = [];
 		foreach (glob("$htmlDir/*.html") as $file) {
@@ -172,11 +135,7 @@ class BuildScripts extends Maintenance {
 		return array_keys($modules);
 	}
 
-	/**
-	 * @return string|null The search module mediawiki.page.ready lazy-loads on
-	 *   focus, after the SkinPageReadyConfig hook (which the active skin and
-	 *   SifterSearch use to point it at their own module), or null if search is off.
-	 */
+	/** @return string|null Search module page.ready lazy-loads on focus, or null if search is off. */
 	private function resolveSearchModule(ResourceLoader $rl, string $lang, string $skin): ?string {
 		$query = ResourceLoader::makeLoaderQuery([], $lang, $skin, null, null, Context::DEBUG_OFF, null);
 		$context = new Context($rl, new FauxRequest($query));
@@ -188,9 +147,7 @@ class BuildScripts extends Maintenance {
 		return $config['search'] ?? false ? $config['searchModule'] ?? null : null;
 	}
 
-	/**
-	 * @return string[] The full dependency closure, including the base modules.
-	 */
+	/** @return string[] The full dependency closure, including the base modules. */
 	private function resolveClosure(ResourceLoader $rl, array $seeds, string $lang, string $skin): array {
 		$query = ResourceLoader::makeLoaderQuery([], $lang, $skin, null, null, Context::DEBUG_OFF, null);
 		$context = new Context($rl, new FauxRequest($query));
@@ -218,8 +175,7 @@ class BuildScripts extends Maintenance {
 			}
 		}
 
-		// jquery and mediawiki.base are implicit base modules; they never appear in
-		// getDependencies() but mw.loader blocks every module until they are ready.
+		// jquery/mediawiki.base are implicit base modules: absent from getDependencies() but required.
 		$resolved['jquery'] = true;
 		$resolved['mediawiki.base'] = true;
 		return array_keys($resolved);

--- a/maintenance/buildStyles.php
+++ b/maintenance/buildStyles.php
@@ -66,10 +66,7 @@ class BuildStyles extends Maintenance {
 
 		$cssDir = "$wgWikvenHtmlDirectory/$wgWikvenStyleDirectory";
 
-		// MediaWiki batches the site styles (MediaWiki:Common.css and the skin's
-		// site CSS) into a single load.php?only=styles link that the static export
-		// drops. Render that module to its own file so rewriteScripts can link it;
-		// an empty result (no MediaWiki:Common.css) is left out.
+		// Render site.styles to its own file so rewriteScripts can link it; skip if empty.
 		$query = ResourceLoader::makeLoaderQuery(
 			['site.styles'],
 			$wgLanguageCode,
@@ -91,9 +88,7 @@ class BuildStyles extends Maintenance {
 			file_put_contents("$cssDir/site.styles.css", $siteStyles, LOCK_EX);
 		}
 
-		// The dumped CSS still points icon background-images at the load.php image
-		// endpoint, which 404s on a static host. Dump each referenced image to a
-		// local file and rewrite the url() to it.
+		// Dumped CSS points icons at load.php images that 404 on static hosts; localize them.
 		AssetLocalizer::localizeImages(
 			$resourceLoader,
 			$cssDir,

--- a/maintenance/fetchExtensions.php
+++ b/maintenance/fetchExtensions.php
@@ -12,35 +12,7 @@ $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 
 require_once "$IP/maintenance/Maintenance.php";
 
-/**
- * Fetch third-party extensions and skins before MediaWiki loads them.
- *
- * The `extensions:` and `skins:` lists in .wikven.yaml stay plain name lists, the
- * same shape MediaWiki's own settings format accepts. A name that is not bundled
- * in the image is fetched here, from a source declared in the `WikvenRepositories`
- * config map. Each entry picks a method by which key it carries:
- *
- *   - `tarball:`    download and extract a tarball (e.g. from ExtensionDistributor,
- *                   whose tarballs already bundle their dependencies). Add a
- *                   `sha256:` to verify the download before extracting.
- *   - `repository:` git clone. Pin it with either `commit:` (an exact SHA, the
- *                   reproducible choice) or `reference:` (a mutable tag/branch),
- *                   and `composer: true` to run composer inside the clone.
- *   - `package:`    a Composer "vendor/name:constraint" installed via the core
- *                   composer.local.json (resolved by composer-merge-plugin).
- *
- * The build downloads and runs whatever these sources resolve to (composer
- * scripts and the fetched code itself execute during the subsequent build), so
- * only trusted sources should be declared. `sha256:`/`commit:` make a fetch
- * tamper-evident and reproducible; a mutable `reference:` or a floating package
- * constraint does not.
- *
- * Whether a name is an extension or a skin is inferred from which list it appears
- * in, so it is never written twice. This runs after install but before
- * WikvenSettings is wired into LocalSettings, so its skins/extensions loops do not
- * yet fire and no "not bundled" warning is logged while a component is still being
- * fetched.
- */
+/** Fetch third-party extensions/skins declared in .wikven.yaml before MediaWiki loads them. */
 class FetchExtensions extends Maintenance {
 	public function __construct() {
 		parent::__construct();
@@ -78,8 +50,7 @@ class FetchExtensions extends Maintenance {
 			[$baseDir, $kind] = $this->target($name, $extensionNames, $skinNames);
 
 			if (isset($spec['package'])) {
-				// Composer chooses the install directory from the package, so there
-				// is nothing to place by hand; just collect the requirement.
+				// Composer picks the install dir from the package; just collect the requirement.
 				if (!is_string($spec['package']) || $spec['package'] === '') {
 					$this->fatalError("Wikven: $kind '$name' has an empty 'package'.");
 				}
@@ -91,8 +62,7 @@ class FetchExtensions extends Maintenance {
 
 			$dest = "$baseDir/$name";
 			if (is_dir($dest)) {
-				// Already bundled in the image, or cloned by an earlier run. The
-				// bundled copy wins; we never overwrite it.
+				// Already bundled or cloned by an earlier run; never overwrite it.
 				$this->output("Wikven: $kind '$name' already present, skipping.\n");
 				continue;
 			}
@@ -114,16 +84,12 @@ class FetchExtensions extends Maintenance {
 		}
 	}
 
-	/**
-	 * Read and merge default.yml + the site config file, exactly as
-	 * WikvenSettings.php does, so the fetched set matches what will be loaded.
-	 */
+	/** Merge default.yml + site config like WikvenSettings.php, so fetches match the load. */
 	private function loadConfig(string $IP): array {
 		$yaml = new YamlFormat();
 		$config = $yaml->decode(file_get_contents("$IP/extensions/Wikven/default.yml"));
 
-		// This runs before the extension registry has activated Wikven's
-		// autoloader, so load the (dependency-free) helper directly.
+		// Wikven's autoloader is not active yet; load the dependency-free helper directly.
 		require_once "$IP/extensions/Wikven/includes/SiteConfig.php";
 		$work = getenv('WIKVEN_WORKDIR');
 		$src = $work !== false && $work !== '' ? "$work/src" : '/workspace/src';
@@ -180,9 +146,7 @@ class FetchExtensions extends Maintenance {
 		return [substr($package, 0, $pos), substr($package, $pos + 1)];
 	}
 
-	/**
-	 * The lowercased, validated `sha256:` of a tarball spec, or null if absent.
-	 */
+	/** The lowercased, validated `sha256:` of a tarball spec, or null if absent. */
 	private function validatedSha256(array $spec, string $name, string $kind): ?string {
 		if (!isset($spec['sha256'])) {
 			return null;
@@ -194,10 +158,7 @@ class FetchExtensions extends Maintenance {
 		return $sha;
 	}
 
-	/**
-	 * The validated `commit:` SHA of a repository spec, or null if absent. Errors
-	 * if it is combined with `reference:`, since the two pin differently.
-	 */
+	/** The validated `commit:` SHA, or null; errors if combined with `reference:`. */
 	private function validatedCommit(array $spec, string $name, string $kind): ?string {
 		if (empty($spec['commit'])) {
 			return null;
@@ -238,9 +199,7 @@ class FetchExtensions extends Maintenance {
 		$commit = $this->validatedCommit($spec, $name, $kind);
 
 		if ($commit !== null) {
-			// Pin to an exact commit. `git clone --branch` only accepts a tag or
-			// branch, so fetch the SHA directly into a fresh repo and detach onto
-			// it (GitHub and most hosts allow fetching a reachable SHA).
+			// `git clone --branch` rejects a SHA, so fetch it into a fresh repo and detach.
 			$this->output("Wikven: cloning $kind '$name' from $repo @ $commit\n");
 			$this->run(['git', 'init', '--quiet', '--', $dest], "init $kind '$name'");
 			$this->run(['git', '-C', $dest, 'remote', 'add', 'origin', $repo], "configure $kind '$name'");
@@ -271,9 +230,7 @@ class FetchExtensions extends Maintenance {
 	}
 
 	private function installPackages(string $IP, array $packages): void {
-		// Core's composer.json merges composer.local.json via composer-merge-plugin,
-		// so registering the requirement there and running composer update at the
-		// root pulls each package (and its dependencies) into place.
+		// Core merges composer.local.json via composer-merge-plugin; require there, then update.
 		$localFile = "$IP/composer.local.json";
 		$local = is_file($localFile)
 			? ( json_decode(file_get_contents($localFile), true) ?: [] )
@@ -291,9 +248,7 @@ class FetchExtensions extends Maintenance {
 	}
 
 	/**
-	 * Run an external command, aborting the build if it fails. A declared
-	 * third-party dependency that cannot be fetched must fail loudly rather than
-	 * silently produce a wiki missing the feature.
+	 * Run an external command, aborting the build loudly if it fails.
 	 *
 	 * @param string[] $cmd
 	 */

--- a/maintenance/importWikitext.php
+++ b/maintenance/importWikitext.php
@@ -42,10 +42,7 @@ class ImportWikitext extends Maintenance {
 				continue;
 			}
 
-			// The static export derives a page's edit/history link filename from
-			// its title. If the title does not round-trip back to this source
-			// file name (MediaWiki normalised it), those links would 404; warn so
-			// the author can rename the file to an already-normalised title.
+			// Warn if the title won't round-trip to the filename; export edit/history links would 404.
 			$relative = substr($filename, strlen($sourceDirectory) + 1);
 			if (SourceFile::titleToFilename($title->getPrefixedText()) !== $relative) {
 				$this->output(
@@ -59,13 +56,7 @@ class ImportWikitext extends Maintenance {
 
 			$this->output("Saving... $title");
 
-			// File: description sidecars and MediaWiki: system pages (Common.js, the
-			// gadget definition and gadget code, ...) are saved as the current
-			// revision via a normal edit. For a File: page the upload already created
-			// it with a default description that an old revision would land behind;
-			// for MediaWiki: pages the edit hooks must fire so registries like the
-			// gadget list are invalidated before the pages render. importOldRevision
-			// would skip both.
+			// File:/MediaWiki: pages need a current-revision edit so upload desc and edit hooks apply.
 			if ($title->getNamespace() === NS_FILE || $title->getNamespace() === NS_MEDIAWIKI) {
 				$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle($title);
 				$updater = $page->newPageUpdater($user);
@@ -75,10 +66,7 @@ class ImportWikitext extends Maintenance {
 				continue;
 			}
 
-			// Import as an old revision (like core's importTextFiles.php with
-			// --use-timestamp) so the source file's modification time becomes the
-			// revision timestamp and the footer shows the real last-modified date
-			// instead of the build time.
+			// Import as an old revision so the file mtime becomes the footer's last-modified timestamp.
 			$revision = new WikiRevision();
 			$revision->setContent(SlotRecord::MAIN, $content);
 			$revision->setTitle($title);
@@ -95,9 +83,7 @@ class ImportWikitext extends Maintenance {
 		}
 
 		if ($failed) {
-			// Report to stderr and signal failure so the caller (build.php's
-			// step()) aborts: a static export that silently drops pages is worse
-			// than no export, and exits 0 either way without this.
+			// Fail loudly so build.php's step() aborts; a silent partial export is worse than none.
 			$this->error(
 				'Failed to import ' . count($failed) . " page(s):\n  " . implode("\n  ", $failed)
 			);
@@ -108,9 +94,7 @@ class ImportWikitext extends Maintenance {
 	}
 
 	/**
-	 * Find every page file under the source directory, recursing into
-	 * subdirectories so subpages can be supplied as nested files (e.g. a
-	 * template's "Template:Foo/styles.css" in a "Template:Foo/" folder).
+	 * Find every page file under the source directory, recursing into subpages.
 	 *
 	 * @return string[] Absolute paths, sorted for a stable import order.
 	 */
@@ -130,10 +114,7 @@ class ImportWikitext extends Maintenance {
 		return $files;
 	}
 
-	/**
-	 * Map a page file to its title: the path relative to the source directory,
-	 * resolved by SourceFile's naming convention.
-	 */
+	/** Map a page file to its title via SourceFile's naming convention. */
 	private function filenameToTitle(string $name, string $sourceDirectory): string {
 		$relative = substr($name, strlen($sourceDirectory) + 1);
 		return SourceFile::filenameToTitle($relative);

--- a/maintenance/rewriteScripts.php
+++ b/maintenance/rewriteScripts.php
@@ -12,17 +12,7 @@ $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 
 require_once "$IP/maintenance/Maintenance.php";
 
-/**
- * Rewrite the cached HTML so the skin JavaScript loads from the static bundle
- * produced by buildScripts.php instead of from load.php (which does not exist
- * on a static host). For each page this:
- *
- *   - empties the inline RLPAGEMODULES queue,
- *   - replaces the async load.php startup <script> with local startup-static.js
- *     + modules-static.js + an explicit mw.loader.load() of the page modules,
- *   - drops the leftover combined load.php stylesheet link (the per-module local
- *     <link>s emitted by the Main hook already cover those styles).
- */
+/** Rewrite cached HTML so skin JS loads from the static bundle instead of load.php. */
 class RewriteScripts extends Maintenance {
 	/** Module groups that are not shipped statically (mirrors Main/buildScripts). */
 	private const SKIP_GROUPS = ['noscript', 'private', 'user'];
@@ -45,16 +35,13 @@ class RewriteScripts extends Maintenance {
 
 		$rl = MediaWikiServices::getInstance()->getResourceLoader();
 
-		// SifterSearch serves search from a static Pagefind bundle and keeps the
-		// native search box working offline (buildScripts bundles its module
-		// closure), so the search box is left in place when it is enabled.
+		// With SifterSearch the static Pagefind bundle keeps the native search box working, so keep it.
 		$sifterEnabled = ExtensionRegistry::getInstance()->isLoaded('SifterSearch');
 
 		foreach (glob("$htmlDir/*.html") as $file) {
 			$html = file_get_contents($file);
 
-			// The modules to re-trigger: the page's own queue minus the groups we do
-			// not ship, so we never load() a module that is not in the bundle.
+			// Modules to re-trigger: page queue minus groups/modules we do not ship.
 			$trigger = [];
 			if (preg_match('/RLPAGEMODULES=(\[[^\]]*\])/', $html, $m)) {
 				$list = json_decode($m[1], true);
@@ -72,9 +59,7 @@ class RewriteScripts extends Maintenance {
 				}
 			}
 
-			// Make sure the site JS (MediaWiki:Common.js plus the skin's JS) and the
-			// gadgets enabled for every reader run: buildScripts bundles them, but
-			// the static render does not queue them, so trigger them here. Dedupe.
+			// Also trigger site JS and default gadgets: bundled but not queued by the static render. Dedupe.
 			$trigger[] = 'site';
 			$trigger = array_merge($trigger, $this->defaultGadgetModules());
 			$trigger = array_values(array_unique($trigger));
@@ -108,9 +93,7 @@ class RewriteScripts extends Maintenance {
 				$html
 			);
 
-			// The dropped combined link carried the site styles (MediaWiki:Common.css
-			// and the skin's site CSS); buildStyles wrote them to their own file.
-			// Link it last, so it wins the cascade over the skin's defaults.
+			// Re-link the site styles last (their own file) so they win the cascade over the skin defaults.
 			if ($hasSiteStyles) {
 				$html = str_replace(
 					'</head>',
@@ -119,27 +102,20 @@ class RewriteScripts extends Maintenance {
 				);
 			}
 
-			// No logo is configured, so the placeholder "change your logo" asset
-			// would 404. Neutralize its reference (the logo itself is CSS-hidden).
+			// No logo configured: neutralize the placeholder asset reference so it does not 404.
 			$html = preg_replace(
 				'#(["\'(])[^"\')]*change-your-logo[^"\')]*\.svg#',
 				'$1data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22/%3E',
 				$html
 			);
 
-			// Without SifterSearch, search cannot work on a static host (it needs the
-			// API) and the JS search widget lazily fetches codex/vue from load.php, so
-			// drop the search boxes and the skin-vector-search-vue body class that
-			// makes the sticky header load the search module, so nothing mounts and
-			// nothing is fetched. With SifterSearch the box is kept (see above).
+			// Without SifterSearch, drop the search boxes and body class so nothing mounts or fetches.
 			if (!$sifterEnabled) {
 				$html = $this->removeElements($html, 'vector-search-box-vue');
 				$html = str_replace(' skin-vector-search-vue', '', $html);
 			}
 
-			// The appearance menu (dark mode / width) pulls in codex+vue from
-			// load.php for its widgets, which 404s and cannot work statically.
-			// Remove it so it stops fetching.
+			// Remove the appearance menu: its widgets pull codex+vue from load.php, which 404s statically.
 			$html = $this->removeElements($html, 'id="vector-appearance"');
 
 			file_put_contents($file, $html, LOCK_EX);
@@ -147,9 +123,7 @@ class RewriteScripts extends Maintenance {
 	}
 
 	/**
-	 * @return string[] Module names of the gadgets enabled for every reader (so
-	 *   they are triggered like the page's own modules), or an empty array when
-	 *   the Gadgets extension is not loaded.
+	 * @return string[] Module names of default-on gadgets, or empty when Gadgets is not loaded.
 	 */
 	private function defaultGadgetModules(): array {
 		$repoClass = 'MediaWiki\\Extension\\Gadgets\\GadgetRepo';
@@ -169,10 +143,7 @@ class RewriteScripts extends Maintenance {
 		return $modules;
 	}
 
-	/**
-	 * Remove every balanced <div ...$marker...>...</div> from the HTML, where
-	 * $marker is a substring of the opening tag. Handles nested <div>s.
-	 */
+	/** Remove every balanced <div ...$marker...>...</div> (nested-aware) from the HTML. */
 	private function removeElements(string $html, string $marker): string {
 		while (true) {
 			$start = $this->findOpeningDiv($html, $marker);
@@ -207,7 +178,6 @@ class RewriteScripts extends Maintenance {
 
 	/**
 	 * Find the end of the <div> opening at byte offset $start.
-	 *
 	 * @return int Byte offset just past the matching </div>, or -1.
 	 */
 	private function matchingDivEnd(string $html, int $start): int {

--- a/maintenance/storeImages.php
+++ b/maintenance/storeImages.php
@@ -11,20 +11,7 @@ $IP = strval(getenv('MW_INSTALL_PATH')) !== ''
 
 require_once "$IP/maintenance/Maintenance.php";
 
-/**
- * Make every image the generated pages reference available next to the HTML,
- * and rewrite the references to those local copies, so the static export is
- * self-contained and never depends on a live MediaWiki install or on
- * upload.wikimedia.org being reachable. Two sources are handled:
- *
- *   - Wikimedia Commons hotlinks (via InstantCommons): downloaded over HTTP.
- *   - Local File: namespace uploads: copied from the upload directory.
- *
- * Files are dumped flat next to the HTML using the same img-<hash>.<ext> scheme
- * as AssetLocalizer. The hash is taken over the reference (the storage path for
- * local files), so each srcset candidate and thumbnail (which differ only by
- * width) becomes its own file.
- */
+/** Localize Commons hotlinks and File: uploads next to the HTML for a self-contained export. */
 class StoreImages extends Maintenance {
 	public function __construct() {
 		parent::__construct();
@@ -41,24 +28,16 @@ class StoreImages extends Maintenance {
 
 		$http = MediaWikiServices::getInstance()->getHttpRequestFactory();
 
-		// Reference as it appears in the HTML => local "./img-*.ext" (or null if
-		// it could not be fetched/found), so each distinct reference is handled once.
+		// HTML reference => local "./img-*.ext" (or null on failure), deduping each reference.
 		$map = [];
 
-		// Local upload URLs ($wgUploadPath/...) as they appear in src, srcset, and
-		// the file page's full-resolution links, with an optional scheme and host.
-		// Group 1 is the storage path; a trailing cache-busting ?query (added on
-		// file pages) is matched so the whole URL is replaced, but excluded from
-		// the path used for the disk lookup.
+		// Match $wgUploadPath URLs; group 1 is the storage path, trailing ?query stripped from it.
 		$localPattern = '~(?:(?:https?:)?//[^/\s"]+)?' . preg_quote($wgUploadPath, '~') . '(/[^\s"?]+)(?:\?[^\s"]*)?~';
 
 		foreach (glob("$dir/*.html") as $file) {
 			$html = file_get_contents($file);
 
-			// Wikimedia Commons URLs only ever appear as src/srcset values; matching
-			// up to the next space or quote isolates each candidate (the srcset width
-			// descriptor that follows is separated by a space) while still allowing
-			// commas inside file names.
+			// Match each Commons src/srcset candidate up to the next space or quote.
 			$html = preg_replace_callback(
 				'~(?:https?:)?//upload\.wikimedia\.org/[^\s"]+~',
 				function ($m) use (&$map, $http, $dir) {
@@ -74,8 +53,7 @@ class StoreImages extends Maintenance {
 			$html = preg_replace_callback(
 				$localPattern,
 				function ($m) use (&$map, $uploadDir, $dir) {
-					// Key by the storage path (without the cache-busting ?query) so the
-					// same file referenced at different sizes or timestamps dedupes.
+					// Key by storage path (no ?query) so sizes/timestamps of one file dedupe.
 					$path = $m[1];
 					if (!array_key_exists($path, $map)) {
 						$map[$path] = $this->storeLocal($uploadDir . $path, $path, $dir);
@@ -93,9 +71,7 @@ class StoreImages extends Maintenance {
 		$this->output("Stored $stored image(s)" . ( $failed ? ", $failed failed" : '' ) . "\n");
 
 		if ($failed) {
-			// The export still hotlinks the images that could not be fetched, so it
-			// is not self-contained; fail so the build (build.php's step()) aborts
-			// rather than publish output that depends on upload.wikimedia.org.
+			// Fail so the build aborts rather than publish output that still hotlinks images.
 			$this->error("Wikven: $failed image(s) could not be made local; the output is not self-contained.");
 			return false;
 		}
@@ -103,8 +79,7 @@ class StoreImages extends Maintenance {
 	}
 
 	/**
-	 * Download a single remote image ($ref, the reference as written in the HTML,
-	 * possibly protocol-relative) into $dir and return its local reference.
+	 * Download remote image $ref into $dir and return its local reference.
 	 *
 	 * @return string|null Local "./img-*.ext" reference, or null on failure.
 	 */
@@ -121,8 +96,7 @@ class StoreImages extends Maintenance {
 			'timeout' => 30,
 			'userAgent' => 'wikven static-site builder (https://github.com/chaotic-ground/wikven)'
 		];
-		// Less common srcset widths may not be cached and 4xx/5xx while Commons
-		// generates the thumbnail on the first hit, so retry with a short backoff.
+		// Retry with backoff: Commons may 4xx/5xx while generating an uncached thumbnail.
 		for ($attempt = 1; $attempt <= 3; $attempt++) {
 			$bytes = $http->get($url, $options, __METHOD__);
 			if ($bytes !== null && $bytes !== '') {


### PR DESCRIPTION
The sources wrapped comments at ~80 columns and carried long multi-line explanatory blocks, which is tiring to read. This makes **every comment a single line of ≤100 chars** across the listed build/tooling configs and the PHP sources.

What changed:
- Condensed multi-line `//` and `/** */` prose comments into one concise line each.
- Dropped comments that merely restated the code.
- Moved the `WikvenRepositories` config-format detail out of `fetchExtensions.php`'s 29-line class docblock; that format is already documented in `Configuration.wikitext` (the SSOT), so the docblock is now a one-line summary.

Safety:
- phpdoc `@param`/`@return`/`@var` annotation tags are preserved (machine-read type info, not prose).
- **No code behaviour changes** — the diff touches only comment lines (verified by filtering the diff for non-comment changes: none).
- Local checks pass: `mago format --check`, `mago lint`, `composer phpcs` (24 files), `yamllint --strict`, `taplo fmt --check`, `gofmt`, `terraform fmt`, `composer test` (minus-x).

Files: `.codecov.yml`, `.phpcs.xml`, `.phan/config.php`, `.tf/ruleset.tf`, `.yamllint.yml`, `Dockerfile`, `bin/build.php`, `bin/run`, `caddy/wikven.go`, `mago.toml`, `includes/**/*.php`, `maintenance/**/*.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)