### PR TITLE
feat(action): default to a pinned image version and cache it between runs

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,8 @@
 			"include-component-in-tag": false,
 			"draft": true,
 			"extra-files": [
-				{ "type": "json", "path": "extension.json", "jsonpath": "$.version" }
+				{ "type": "json", "path": "extension.json", "jsonpath": "$.version" },
+				{ "type": "generic", "path": "action/action.yml" }
 			],
 			"changelog-sections": [
 				{ "type": "feat", "section": "Features" },

--- a/action/action.yml
+++ b/action/action.yml
@@ -14,19 +14,41 @@ inputs:
     default: dist
   image:
     description: >-
-      The wikven image to run. Defaults to the rolling latest; pin a release
-      (e.g. ghcr.io/chaotic-ground/wikven:1.0.0) for reproducible builds.
-    default: ghcr.io/chaotic-ground/wikven:latest
+      The wikven image to run. Defaults to the release this action was cut from;
+      override to pin a different tag (e.g. ghcr.io/chaotic-ground/wikven:1.2.3).
+    default: ghcr.io/chaotic-ground/wikven:0.1.0  # x-release-please-version
+  cache:
+    description: >-
+      Cache the pulled image between runs, keyed on the image ref. Set to
+      "false" to always pull fresh.
+    default: "true"
 
 runs:
   using: composite
   steps:
+    # The image ref is immutable per tag, so a cache hit needs no re-pull.
+    - if: inputs.cache == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
+      with:
+        path: ~/.cache/wikven/image.tar
+        key: wikven-image-${{ inputs.image }}
     - shell: bash
       env:
         SOURCE: ${{ inputs.source }}
         OUTPUT: ${{ inputs.output }}
         IMAGE: ${{ inputs.image }}
+        CACHE: ${{ inputs.cache }}
       run: |
+        tar="$HOME/.cache/wikven/image.tar"
+        if [ "$CACHE" = "true" ] && [ -f "$tar" ]; then
+          docker load -i "$tar"
+        else
+          docker pull "$IMAGE"
+          if [ "$CACHE" = "true" ]; then
+            mkdir -p "$(dirname "$tar")"
+            docker save "$IMAGE" -o "$tar"
+          fi
+        fi
         mkdir -p "$OUTPUT"
         docker run --rm \
           -v "$PWD/$SOURCE:/workspace/src" \


### PR DESCRIPTION
Two improvements to the composite action.

### Pinned image default, owned by release-please
The `image` input defaulted to the rolling `ghcr.io/chaotic-ground/wikven:latest`. It now defaults to a **pinned release tag**, so a build is reproducible without the caller having to pin anything.

release-please keeps it current: `action/action.yml` is registered as a `generic` extra-file in `.release-please-config.json`, and the default line carries an `x-release-please-version` annotation. Each release publishes `…/wikven:<version>` (the existing docker job already pushes `:X.Y.Z`, `:X.Y`, `:X`, `:latest`) and bumps this default to match.

```yaml
    default: ghcr.io/chaotic-ground/wikven:0.1.0  # x-release-please-version
```

### Image caching (default on)
A new `cache` input (default `"true"`) caches the pulled image with `actions/cache`, keyed on the image ref. Because a tag is immutable, a cache hit `docker load`s the saved image and skips the pull; `cache: "false"` always pulls fresh.

### Checks
`zizmor` (no findings), `yamllint --strict`, and `biome check` all pass locally. `actions/cache` is SHA-pinned (`v6.1.0`); all `${{ }}` values reach the shell via `env:`, never interpolated into `run:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)