### PR TITLE
docs: fix stale .yaml workflow references after the .yml unification

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -2,7 +2,7 @@
 name: Build binary
 
 # Reusable: build the standalone binary for each architecture and attach it to
-# the given release tag. Called by release-please.yaml and nightly.yaml.
+# the given release tag. Called by release-please.yml and nightly.yml.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      # Build with the shared GHA layer cache (same scope as docker-build.yaml)
+      # Build with the shared GHA layer cache (same scope as docker-build.yml)
       # and load the image locally so the bake step below can run it.
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:

--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -81,10 +81,10 @@ The same MediaWiki + {{wikven}} tree is embedded into a single [[Binary|FrankenP
 
 == Continuous integration ==
 
-* <code>lint.yaml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, zizmor).
-* <code>docker-build.yaml</code> builds the image and publishes it to <code>ghcr.io/chaotic-ground/wikven</code> on <code>main</code>.
-* <code>deploy-docs.yaml</code> builds the <code>docs/</code> directory with the image and deploys the result to GitHub Pages, so this site is itself a {{wikven}} build.
-* <code>build-binary.yaml</code> is a reusable workflow that builds the standalone [[Binary|binary]] for each platform. <code>release-please.yaml</code> calls it to attach the binaries to a version release, and <code>nightly.yaml</code> calls it daily to publish a dated <code>nightly-YYYY-MM-DD</code> pre-release. Both create the release as a draft, attach the binaries, then publish it, because GitHub's immutable releases lock a release's assets once it is published.
-* <code>release-please.yaml</code> manages versioning and releases (see below).
+* <code>lint.yml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, yamllint, zizmor, and phpcs).
+* <code>docker-build.yml</code> builds the image and publishes it to <code>ghcr.io/chaotic-ground/wikven</code> on <code>main</code>.
+* <code>deploy-docs.yml</code> builds the <code>docs/</code> directory with the image and deploys the result to GitHub Pages, so this site is itself a {{wikven}} build.
+* <code>build-binary.yml</code> is a reusable workflow that builds the standalone [[Binary|binary]] for each platform. <code>release-please.yml</code> calls it to attach the binaries to a version release, and <code>nightly.yml</code> calls it daily to publish a dated <code>nightly-YYYY-MM-DD</code> pre-release. Both create the release as a draft, attach the binaries, then publish it, because GitHub's immutable releases lock a release's assets once it is published.
+* <code>release-please.yml</code> manages versioning and releases (see below).
 
 Versions follow [https://www.conventionalcommits.org/ Conventional Commits], which release-please uses to generate the changelog and bump the version.


### PR DESCRIPTION
The `.yml` unification (#178) renamed every workflow file but missed prose references to the old names:

- `docs/Development.wikitext` (CI section): `lint.yaml`, `docker-build.yaml`, `deploy-docs.yaml`, `build-binary.yaml`, `release-please.yaml`, `nightly.yaml` → their `.yml` names.
- `build-binary.yml` comment: "Called by release-please.yaml and nightly.yaml" → `.yml`.
- `smoke.yml` comment: "same scope as docker-build.yaml" → `.yml`.

Also completed the lint-job list in that section with `yamllint` and `phpcs`, which it had not listed (yamllint was added in #178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)