### PR TITLE
build: depend on the shared mago-mediawiki-style config via extends

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,12 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
+        with:
+          php-version: "8.3"
+          tools: composer
+      # mago.toml extends the shared style config installed under vendor/, so install it first.
+      - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
       - uses: nhedger/setup-mago@473d3a2bfe0b32a62c8b910059d7f03a16519f2e  # v2.0.0
         with:
           version: "1.29.0"

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,19 @@
 		"phpcbf": "phpcbf"
 	},
 	"require-dev": {
+		"chaotic-ground/mago-mediawiki-style": "^0.1",
 		"mediawiki/mediawiki-codesniffer": "51.0.0",
 		"mediawiki/mediawiki-phan-config": "0.20.0",
 		"mediawiki/minus-x": "2.0.1",
 		"phpro/grumphp": "2.21.0"
 	},
+	"repositories": [
+		{
+			"type": "vcs",
+			"url": "https://github.com/chaotic-ground/mago-mediawiki-style",
+			"no-api": true
+		}
+	],
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,

--- a/mago.toml
+++ b/mago.toml
@@ -1,4 +1,6 @@
-# Approximates MediaWiki coding style; tracked at chaotic-ground/mago-mediawiki-style.
+# Formatter style comes from the shared mago-mediawiki-style package; the linter rules and
+# use-sorting below are wikven's own.
+extends = "vendor/chaotic-ground/mago-mediawiki-style/style.toml"
 
 # MediaWiki 1.45 (base image) needs PHP 8.1+, so lint against 8.1 though the binary runs newer.
 php-version = "8.1"
@@ -7,49 +9,10 @@ php-version = "8.1"
 paths = ["includes", "maintenance", "tests"]
 
 [formatter]
-print-width = 120
-tab-width = 4
-use-tabs = true
-single-quote = true
-
-# MediaWiki does not require trailing commas.
-trailing-comma = false
-
-# MediaWiki places every opening brace on the same line.
-control-brace-style = "same-line"
-closure-brace-style = "same-line"
-function-brace-style = "same-line"
-method-brace-style = "same-line"
-classlike-brace-style = "same-line"
-
-# MediaWiki: `(int)$var`, not `(int) $var`.
-space-after-cast-unary-prefix-operators = false
-
-# MediaWiki puts spaces inside grouping parentheses: `( $a + $b )`.
-space-within-grouping-parenthesis = true
-
-# MediaWiki files start with `<?php` immediately followed by code or a
-# file-level doc comment.
-empty-line-after-opening-tag = false
-
-# MediaWiki does not align array tables or assignments.
-array-table-style-alignment = false
-
-# Sort use statements, matching mediawiki-codesniffer's UnsortedUseStatements.
+# wikven sorts use statements (mediawiki-codesniffer style); the shared config leaves them as-is.
 sort-uses = true
-separate-use-types = false
 
-# Preserve author line-breaking decisions to keep the diff minimal.
-preserve-breaking-member-access-chain = true
-preserve-breaking-member-access-chain-first-method-on-same-line = true
-preserve-breaking-argument-list = true
-preserve-breaking-parameter-list = true
-preserve-breaking-attribute-list = true
-preserve-breaking-conditional-expression = true
-preserve-breaking-condition-expression = true
-
-# Disable lint rules that conflict with the MediaWiki coding style or are noisy
-# metrics, keeping only correctness-oriented rules.
+# Disable noisy metric/style lint rules, keeping only the correctness-oriented ones.
 [linter.rules]
 braced-string-interpolation = { enabled = false }
 literal-named-argument = { enabled = false }


### PR DESCRIPTION
wikven's `mago.toml` carried a hand-maintained copy of the MediaWiki formatter style that had to be kept in sync with [chaotic-ground/mago-mediawiki-style](https://github.com/chaotic-ground/mago-mediawiki-style). It now **depends on** that config instead, the mago equivalent of how `.phpcs.xml` references `mediawiki/mediawiki-codesniffer`.

### How
- `composer.json`: add the package as `require-dev` via a Composer **VCS** repository (no Packagist), pinned `^0.1`.
- `mago.toml`: `extends = "vendor/chaotic-ground/mago-mediawiki-style/style.toml"` for the formatter style.
- `lint.yml`: the `mago` job now runs `composer install` so the extended file exists under `vendor/`.

### What stays local to wikven
- `php-version` and the source paths.
- `sort-uses = true` — wikven follows mediawiki-codesniffer's sorted use statements; the parity tracker keeps them unsorted to minimise its diff against MediaWiki core.
- the `[linter.rules]` block that disables mago's noisy metric/style rules.

### No behaviour change
The effective formatter **and** linter config is byte-for-byte identical to before (verified with `mago config --show`): `mago format --check` reports no churn and `mago lint` reports no issues. Upstream prep merged as chaotic-ground/mago-mediawiki-style#1 and tagged `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)