### PR TITLE
docs: steer macOS users to Docker and explain the missing mac binary

### DIFF
--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -2,6 +2,8 @@ __TOC__
 
 Besides the [[Installation#Docker|Docker image]], {{wikven}} ships as a single self-contained executable that embeds MediaWiki, so you can build a site without Docker. It is available for Linux on x86_64 and arm64.
 
+On macOS and Windows, use the [[Installation#Docker|Docker image]] instead. {{wikven}} provides no prebuilt macOS binary, for cost reasons: for a downloaded binary to run without Gatekeeper blocking it, Apple requires it to be signed and notarized through a paid Apple Developer Program account (US$99/year), and that cost is not justified for the project yet. The only alternative, telling users to clear the quarantine by hand, trains them to bypass a security check, so it is not offered. A macOS user who wants a binary regardless can compile one from source with [https://frankenphp.dev/docs/static/ FrankenPHP's static build]; a locally built binary is not quarantined.
+
 == Download ==
 
 Download the binary for your architecture from the [https://github.com/chaotic-ground/wikven/releases latest release] and make it executable:


### PR DESCRIPTION
The Binary page advertised Linux binaries but said nothing to a macOS reader looking for one.

Adds an explicit note to `Binary.wikitext`:
- On macOS (and Windows), use the Docker image.
- **wikven provides no prebuilt macOS binary, for cost reasons**: a downloaded binary must be signed and notarized through a paid Apple Developer Program account (US$99/year) to clear Gatekeeper, and that cost isn't justified for the project yet. Telling users to clear the quarantine by hand (`xattr`) trains them to bypass a security check, so it isn't offered.
- A determined macOS user can compile one from source with FrankenPHP's static build (a locally built binary isn't quarantined).

No code or workflow change — `build-binary.yml` already builds Linux-only, and `Installation.wikitext` already points macOS/Windows users at Docker. This just makes the Binary page say so explicitly, with the honest reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)