### PR TITLE
docs: note there is no Windows binary yet, linking the tracking issue

### DIFF
--- a/docs/Binary.wikitext
+++ b/docs/Binary.wikitext
@@ -4,6 +4,8 @@ Besides the [[Installation#Docker|Docker image]], {{wikven}} ships as a single s
 
 On macOS and Windows, use the [[Installation#Docker|Docker image]] instead. {{wikven}} provides no prebuilt macOS binary, for cost reasons: for a downloaded binary to run without Gatekeeper blocking it, Apple requires it to be signed and notarized through a paid Apple Developer Program account (US$99/year), and that cost is not justified for the project yet. The only alternative, telling users to clear the quarantine by hand, trains them to bypass a security check, so it is not offered. A macOS user who wants a binary regardless can compile one from source with [https://frankenphp.dev/docs/static/ FrankenPHP's static build]; a locally built binary is not quarantined.
 
+There is no prebuilt Windows binary either: the toolchain that produces a single self-contained executable does not support Windows yet (see [https://github.com/chaotic-ground/wikven/issues/192 issue #192]).
+
 == Download ==
 
 Download the binary for your architecture from the [https://github.com/chaotic-ground/wikven/releases latest release] and make it executable:


### PR DESCRIPTION
Adds one line to the Binary page's platform note: there is no prebuilt Windows binary because the single-self-contained-executable toolchain (static-php-cli embed) doesn't support Windows yet.

Links **#192**, which records the full investigation:
- FrankenPHP gained native Windows support (March 2026), but it's **dynamically linked** against the official PHP DLLs, not a single self-contained file.
- **static-php-cli can't build a static, embeddable PHP on Windows** yet (needs PHP source patches), so `--with-frankenphp-app` embedding isn't available there.
- `build-static.sh` is Unix-only anyway.
- Windows users → Docker image (Docker Desktop / WSL2); the Linux binary also runs under WSL2.

Closes nothing; #192 stays open as the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)