### PR TITLE
fix(action): use a locally-built image instead of always pulling

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -59,6 +59,7 @@ jobs:
           source: docs
           output: dist
           image: wikven
+          cache: false  # the image was just built locally; nothing to cache or pull
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:

--- a/action/action.yml
+++ b/action/action.yml
@@ -42,7 +42,8 @@ runs:
         tar="$HOME/.cache/wikven/image.tar"
         if [ "$CACHE" = "true" ] && [ -f "$tar" ]; then
           docker load -i "$tar"
-        else
+        elif ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+          # Not cached and not already local (a registry ref): pull it. A local build is used as-is.
           docker pull "$IMAGE"
           if [ "$CACHE" = "true" ]; then
             mkdir -p "$(dirname "$tar")"


### PR DESCRIPTION
**Bug:** the docs site has not deployed since #188.

PR #188 (action image caching) made the composite action `docker pull "$IMAGE"` on a cache miss. But `deploy-docs` builds the image locally as `wikven` and bakes the docs through the action, so the pull failed:

```
Error response from daemon: pull access denied for wikven, repository does not exist or may require 'docker login'
```

The "Bake the docs site" step failed, the Pages deploy was skipped, and the macOS/Windows doc updates never went live.

**Fix:** pull only when the image is neither cached nor already present locally (`docker image inspect`). A locally-built image is now used as-is. `deploy-docs` also passes `cache: false`, since its freshly-built image needs no caching.

Verified locally: with the `wikven` image built, the action selects "use local image (no pull)" and bakes a source tree to completion.

After merge I'll manually dispatch `deploy-docs` to republish the site (the fix only touches `action/action.yml` + `deploy-docs.yml`, which aren't in deploy-docs's trigger paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)