### PR TITLE
fix: hide dead skin chrome left by the static export in Timeless and Citizen

### DIFF
--- a/docs/.wikven.yml
+++ b/docs/.wikven.yml
@@ -34,8 +34,8 @@ config:
       repository: https://github.com/StarCitizenTools/mediawiki-extensions-TabberNeue.git
       reference: v4.0.0
     # Citizen is a third-party skin; its search is its own REST-backed command
-    # palette, which has no backend on a static export, so it is hidden (see
-    # Adder.php). The other skins keep working SifterSearch search.
+    # palette with no backend on a static export, so MediaWiki:Citizen.css hides
+    # it. The other skins keep working SifterSearch search.
     Citizen:
       repository: https://github.com/StarCitizenTools/mediawiki-skins-Citizen.git
       reference: v3.17.0

--- a/docs/MediaWiki:Citizen.css
+++ b/docs/MediaWiki:Citizen.css
@@ -1,0 +1,22 @@
+/* Static-export fixes for the Citizen skin, which this site fetches rather than wikven bundling
+ * it, so these live here instead of in wikven's own skin handling. */
+
+/* A static site has no login session or REST search backend, so Citizen's personal menu,
+ * preferences dropdown ("Couldn't load preferences"), and command-palette search are dead. */
+.citizen-userMenu,
+.citizen-preferences-dropdown,
+.citizen-search {
+	display: none !important;
+}
+
+/* Common.css recolours the external-link arrow but leaves the skin to size and position it.
+ * Citizen's positioning rule is missing from the export, so the arrow tiles as repeated boxes;
+ * drop it (external links keep their colour, just without the indicator). */
+.mw-parser-output a.external {
+	background: none;
+	padding-inline-end: 0;
+}
+
+.mw-parser-output a.external::after {
+	content: none;
+}

--- a/includes/Hooks/Adder.php
+++ b/includes/Hooks/Adder.php
@@ -25,10 +25,11 @@ class Adder implements \MediaWiki\Hook\BeforePageDisplayHook, \MediaWiki\Hook\Sk
 			$out->addJsConfigVars('wgWikvenMainSkin', $GLOBALS['wgWikvenMainSkin'] ?? '');
 		}
 
-		// Citizen's REST search has no backend on the static build; hide it only on cli export.
-		if (MW_ENTRY_POINT === 'cli' && $skin->getSkinName() === 'citizen') {
-			// !important: .citizen-dropdown's display:flex would otherwise win by cascade order.
-			$out->addInlineStyle('.citizen-search { display: none !important; }');
+		// A static export has no user session or server logs, so Timeless's personal-tools dropdown
+		// and its "Page tools" sidebar (page actions, Special:Log) are dead; hide them on cli export.
+		// !important: the skin stylesheet loads after this inline rule and would otherwise win.
+		if (MW_ENTRY_POINT === 'cli' && $skin->getSkinName() === 'timeless') {
+			$out->addInlineStyle('#user-tools, #page-tools { display: none !important; }');
 		}
 	}
 


### PR DESCRIPTION
A static export strips the server-backed tools a skin assumes, but some skins still render the now-empty or dead chrome. Two skins this docs site uses showed leftovers (verified in a headless browser at desktop width):

## Timeless (bundled → fixed in wikven core)

- **Personal-tools dropdown** (`#user-tools`, "Anonymous") — no session, opens nothing.
- **"Page tools" sidebar** (`#page-tools`) — empty page-actions overflow plus a **"Page logs" → `Special:Log`** link the export doesn't produce.

`Adder` now hides `#user-tools, #page-tools` on the cli export (`!important`, since the skin stylesheet loads after the inline rule). This replaces the old Citizen-specific rule that lived there.

## Citizen (fetched, not bundled → fixed in `MediaWiki:Citizen.css`)

- **Personal menu** and **preferences dropdown** ("Couldn't load preferences" — needs an API) are dead; **search** is the REST command palette with no static backend. All three hidden.
- **External links rendered as rows of boxes**: `Common.css` recolours the external-link arrow but leaves the skin to size/position it; Citizen's positioning rule is absent from the export, so the arrow tiled with `background-repeat: repeat`. The icon is dropped.

Moving Citizen's search-hide out of `Adder` into `MediaWiki:Citizen.css` keeps wikven core free of rules for a skin it doesn't bundle (matching how Citizen is otherwise treated).

## Verification

Baked the docs and inspected both skins headless at 1440px:
- Timeless: `#user-tools` and `#page-tools` hidden; search box + nav intact.
- Citizen: personal/preferences/search hidden; external links (`MediaWiki`, `Wikipedia`) render cleanly with no boxes; hamburger nav intact.
- `phpcs`, `mago`, `biome ci`, `yamllint --strict` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)