### PR TITLE
ci: label workflow steps by name and condense their comments

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -33,13 +33,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # The standalone binary embeds the same MediaWiki + Wikven tree the image
-      # ships, so build that image first, then embed it into a FrankenPHP binary.
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      # Build and load the embedding image with a per-architecture GHA layer
-      # cache, so repeated (e.g. nightly) builds reuse the base + apt layers.
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+      - name: Build the wikven image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           load: true
@@ -47,9 +44,7 @@ jobs:
           cache-from: type=gha,scope=wikven-image-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=wikven-image-${{ matrix.arch }}
 
-      # Classic build: it reads the loaded `wikven` image via FROM and exports
-      # the compiled binary (-o type=local); the static PHP compile that
-      # dominates here re-runs whenever the source changes regardless.
+      # binary.Dockerfile's export target FROMs the loaded image and writes out the compiled binary.
       - name: Build the standalone binary
         run: docker build -f binary.Dockerfile --target export -o type=local,dest=out .
 
@@ -59,8 +54,9 @@ jobs:
       - name: Generate the checksum
         run: sha256sum "wikven-linux-${{ matrix.arch }}" > "wikven-linux-${{ matrix.arch }}.sha256"
 
-      # Signed SLSA provenance, so users can `gh attestation verify` the binary.
-      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
+      # Sign the build provenance so users can `gh attestation verify` the binary.
+      - name: Attest the binary
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-path: wikven-linux-${{ matrix.arch }}
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,8 +43,8 @@ jobs:
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      # Build this commit's image (shared GHA layer cache) and load it locally.
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+      - name: Build and load this commit's image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           load: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,8 +39,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # On a release (tag input set) publish the immutable version tags plus
-      # latest; otherwise just latest. inputs.tag is empty for push/PR runs.
+      # On a release (tag input set) publish the immutable version tags plus latest, else just latest.
       - name: Compute image tags
         id: tags
         env:
@@ -54,12 +53,12 @@ jobs:
             printf 'tags=%s\n' "$img:latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+      - name: Build and push the image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           push: ${{ github.repository_owner == 'chaotic-ground' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.tags.outputs.tags }}
-          # Layer cache shared (scope) with the other image builds, so a PR
-          # reuses main's cached base + apt layers instead of a cold rebuild.
+          # Layer cache shared with the other image builds, so a PR reuses main's cached layers.
           cache-from: type=gha,scope=wikven-image
           cache-to: type=gha,mode=max,scope=wikven-image

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -84,9 +84,7 @@ jobs:
           persist-credentials: false
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89  # v1.47.2
 
-  # MediaWiki coding-standard checks that mago (the formatter) does not cover:
-  # documentation, naming, forbidden patterns, and other semantic rules. The
-  # whitespace sniffs mago owns are excluded in .phpcs.xml.
+  # MediaWiki coding-standard checks mago doesn't cover: docs, naming, and forbidden patterns.
   phpcs:
     runs-on: ubuntu-latest
     steps:
@@ -95,11 +93,9 @@ jobs:
           persist-credentials: false
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240  # 2.37.2
         with:
-          # The lint tools (codesniffer, grumphp, minus-x) require PHP >= 8.2;
-          # this is only the environment phpcs runs in, not wikven's target.
+          # Lint tools (codesniffer, grumphp, minus-x) need PHP >= 8.2; just the runner, not wikven's target.
           php-version: "8.3"
           tools: composer
-      # mediawiki-phan-config (a dev dep, used only by the Quibble phan job)
-      # pulls in phan, which requires ext-ast; phpcs does not need it.
+      # mediawiki-phan-config pulls in phan (needs ext-ast); phpcs doesn't, so ignore that platform req.
       - run: composer install --no-interaction --no-progress --ignore-platform-req=ext-ast
       - run: composer phpcs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,8 +15,7 @@ on:
 permissions: {}
 
 jobs:
-  # Build only when a feat/fix landed since the last nightly; a scheduled run
-  # after only chores/CI is skipped.
+  # Build only when a feat/fix landed since the last nightly; skip a run with only chores/CI.
   gate:
     runs-on: ubuntu-latest
     outputs:
@@ -54,9 +53,7 @@ jobs:
         id: meta
         run: echo "tag=nightly-$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
-      # Create the pre-release as a draft so the binary job can attach assets;
-      # immutable releases only lock once published. Drop any leftover draft from
-      # a failed same-day run first.
+      # A draft stays mutable so the binary job can attach assets; drop any leftover same-day draft first.
       - name: Create the dated draft pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -90,8 +87,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # Publishing locks the assets under immutable releases, so do it only once
-      # every architecture has been attached.
+      # Publishing locks the assets, so do it only once every architecture has been attached.
       - name: Publish the dated pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -9,8 +9,7 @@ on:
 permissions: {}
 
 jobs:
-  # phan needs a full MediaWiki environment to resolve core symbols, which neither
-  # mago's analyzer nor a bare phpcs run can provide.
+  # phan needs a full MediaWiki environment to resolve core symbols; mago and phpcs can't provide one.
   phan:
     runs-on: ubuntu-latest
     strategy:
@@ -25,9 +24,7 @@ jobs:
         with:
           stage: phan
           mediawiki-version: ${{ matrix.mediawiki-version }}
-          # PHP 8.3 image, so the container resolves wikven's dev deps (which
-          # require >= 8.2). phan itself runs in the action's default
-          # mediawiki-phan-testrun image (php-ast 1.1.3, the maintained one).
+          # PHP 8.3 image so the container resolves wikven's dev deps (>= 8.2); phan runs in the action's testrun image.
           quibble-docker-image: quibble-bookworm-php83
 
   composer-test:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,13 +21,10 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7  # v5.0.0
         id: release
         with:
-          # The config is a dotfile to match the manifest (.release-please-manifest.json,
-          # already dot-prefixed by default); the action's config-file input points at it.
+          # Dotfile config to match the dot-prefixed manifest; config-file points the action at it.
           config-file: .release-please-config.json
 
-  # release-please creates the GitHub release as a draft (see
-  # .release-please-config.json) so the binaries can be attached before it is
-  # published — immutable releases lock a release's assets at publish time.
+  # release-please drafts the release (immutable releases lock assets at publish), so binaries attach first.
   binary:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
@@ -39,9 +36,7 @@ jobs:
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
 
-  # Publish a versioned, pinnable image (ghcr.io/.../wikven:1.0.0, :1.0, :1,
-  # :latest) so the Docker install path matches the release, not a rolling
-  # :latest rebuilt on every merge to main.
+  # Publish a versioned, pinnable image (:1.0.0, :1.0, :1, :latest) so the install path matches the release.
   docker:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -45,9 +45,9 @@ jobs:
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      # Build with the shared GHA layer cache (same scope as docker-build.yml)
-      # and load the image locally so the bake step below can run it.
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+      # Shared GHA layer cache (same scope as docker-build.yml); load locally so the bake can run it.
+      - name: Build and load the wikven image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           load: true
@@ -66,13 +66,10 @@ jobs:
       - name: Assert the bake produced a complete, self-contained site
         run: |
           set -euo pipefail
-          # The main page must land at the dist root (the build aborts on a
-          # failed import, so reaching here already means exit 0).
+          # The main page must land at the dist root (a failed import already aborted the build).
           test -s dist/index.html
 
-          # Dumped CSS must not reference load.php: that endpoint only exists in
-          # a live MediaWiki, so a leftover is an AssetLocalizer regression that
-          # leaves the static site fetching styles from a server that is not there.
+          # Dumped CSS must not reference load.php (a live-only endpoint); a leftover is an AssetLocalizer regression.
           if grep -rIl --include='*.css' 'load\.php' dist; then
             echo "::error::dumped CSS still references load.php (AssetLocalizer regression)"
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,7 @@ on:
 permissions: {}
 
 jobs:
-  # Compile the Caddy plugin so a Go build error is caught on the PR rather than
-  # only later, inside the release/nightly binary build.
+  # Compile the Caddy plugin so a Go build error is caught on the PR, not later in the binary build.
   caddy:
     runs-on: ubuntu-latest
     steps:
@@ -26,8 +25,7 @@ jobs:
       - run: go vet ./...
         working-directory: caddy
 
-  # Run the extension's PHPUnit tests against a real MediaWiki: the 1.45 base
-  # the build ships on, and master.
+  # Run the extension's PHPUnit tests against a real MediaWiki: the 1.45 base the build ships on, and master.
   phpunit:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Extends the `build-binary.yml` cleanup to the sibling workflows, same convention throughout:

- Each unnamed `uses:`/`run:` step that carried an explanatory comment gets a descriptive `name:`, so the Actions UI reads as a labelled step list (`Build and push the image`, `Build and load this commit's image`, `Build and load the wikven image`, …).
- Multi-line explanatory comments are condensed to a single line each (or dropped where a step name now makes them obvious).
- Drops an em dash from a `release-please.yml` comment.

No behaviour change, only step names and comments. `yamllint --strict` passes (lines stay under the 120 cap).