### PR TITLE
chore: gitignore the local binary build output dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /vendor/
 /composer.lock
 /dist/
+/out/
 
 # OpenTofu / Terraform
 /.tf/.terraform/


### PR DESCRIPTION
`binary.Dockerfile --target export -o type=local,dest=out` writes the standalone binary to `out/` (~500 MB). Ignore it so a local binary build can't be committed by accident, alongside the existing `/dist/` output.