### PR TITLE
docs: move the binary page into References and put Getting Started after Installation

### DIFF
--- a/docs/Configuration.wikitext
+++ b/docs/Configuration.wikitext
@@ -85,7 +85,7 @@ config:
 
 A name in <code>WikvenRepositories</code> that is already bundled with wikven is left untouched. A name that is not also listed in <code>extensions</code> or <code>skins</code> is an error.
 
-Each method needs a host tool present at build time: <code>tarball</code> uses <code>curl</code> and <code>tar</code>, <code>repository</code> uses <code>git</code> (and Composer when <code>composer: true</code>), and <code>package</code> uses Composer. The Docker image bundles all of these; with the standalone [[Binary|binary]] they must be on your <code>PATH</code>.
+Each method needs a host tool present at build time: <code>tarball</code> uses <code>curl</code> and <code>tar</code>, <code>repository</code> uses <code>git</code> (and Composer when <code>composer: true</code>), and <code>package</code> uses Composer. The Docker image bundles all of these; with the standalone [[Standalone binary|binary]] they must be on your <code>PATH</code>.
 
 {{note|The build downloads and '''runs''' the code you name here, with network access: a cloned extension's PHP and any Composer scripts execute during the build. Only declare sources you trust. For a tamper-evident, reproducible build, pin a tarball with <code>sha256</code> and a repository with <code>commit</code> (an exact SHA); a mutable <code>reference</code> tag/branch or a floating <code>package</code> constraint can change underneath you.}}
 
@@ -109,4 +109,4 @@ docker run --rm --entrypoint cat ghcr.io/chaotic-ground/wikven extensions/Wikven
 
 It is also in the [https://github.com/chaotic-ground/wikven/blob/main/default.yml repository].
 
-{{prevnext|Troubleshooting|Development}}
+{{prevnext|Troubleshooting|Standalone binary}}

--- a/docs/Deploying.wikitext
+++ b/docs/Deploying.wikitext
@@ -47,7 +47,7 @@ Because <code>dist/</code> is just files, you can serve it from any static host 
 
 Open <code>dist/index.html</code> directly, or serve the directory so links and assets resolve exactly as they will in production. {{wikven}} has a built-in <code>serve</code> command for this.
 
-With the [[Binary|standalone binary]], it serves <code>dist/</code> on <code>http://localhost:8080</code> (override with <code>--listen</code>):
+With the [[Standalone binary|standalone binary]], it serves <code>dist/</code> on <code>http://localhost:8080</code> (override with <code>--listen</code>):
 
 <syntaxhighlight lang="shell">
 wikven serve

--- a/docs/Development.wikitext
+++ b/docs/Development.wikitext
@@ -28,7 +28,7 @@ docker run --rm \
   wikven
 </syntaxhighlight>
 
-The container mounts the source at <code>/workspace/src</code> and writes the rendered site to <code>/workspace/dist</code>. Both paths derive from <code>WIKVEN_WORKDIR</code> (default <code>/workspace</code>), which also has a <code>.cache/</code> for ephemeral state; the same layout lets the [[Binary|standalone binary]] point everything at a writable host directory.
+The container mounts the source at <code>/workspace/src</code> and writes the rendered site to <code>/workspace/dist</code>. Both paths derive from <code>WIKVEN_WORKDIR</code> (default <code>/workspace</code>), which also has a <code>.cache/</code> for ephemeral state; the same layout lets the [[Standalone binary|standalone binary]] point everything at a writable host directory.
 
 The <code>run</code> script:
 
@@ -77,14 +77,14 @@ Names in <code>extensions</code>/<code>skins</code> that are not bundled with {{
 
 == Standalone binary ==
 
-The same MediaWiki + {{wikven}} tree is embedded into a single [[Binary|FrankenPHP executable]] (see <code>binary.Dockerfile</code>), so a site can be built with no Docker. The binary extracts its app to a writable temporary directory at startup and runs the same pipeline, which is why all writable paths are kept under <code>WIKVEN_WORKDIR</code>.
+The same MediaWiki + {{wikven}} tree is embedded into a single [[Standalone binary|FrankenPHP executable]] (see <code>binary.Dockerfile</code>), so a site can be built with no Docker. The binary extracts its app to a writable temporary directory at startup and runs the same pipeline, which is why all writable paths are kept under <code>WIKVEN_WORKDIR</code>.
 
 == Continuous integration ==
 
 * <code>lint.yml</code> runs the formatters and linters (Biome, mago, rumdl, taplo, typos, yamllint, zizmor, and phpcs).
 * <code>docker-build.yml</code> builds the image and publishes it to <code>ghcr.io/chaotic-ground/wikven</code> on <code>main</code>.
 * <code>deploy-docs.yml</code> builds the <code>docs/</code> directory with the image and deploys the result to GitHub Pages, so this site is itself a {{wikven}} build.
-* <code>build-binary.yml</code> is a reusable workflow that builds the standalone [[Binary|binary]] for each platform. <code>release-please.yml</code> calls it to attach the binaries to a version release, and <code>nightly.yml</code> calls it daily to publish a dated <code>nightly-YYYY-MM-DD</code> pre-release. Both create the release as a draft, attach the binaries, then publish it, because GitHub's immutable releases lock a release's assets once it is published.
+* <code>build-binary.yml</code> is a reusable workflow that builds the standalone [[Standalone binary|binary]] for each platform. <code>release-please.yml</code> calls it to attach the binaries to a version release, and <code>nightly.yml</code> calls it daily to publish a dated <code>nightly-YYYY-MM-DD</code> pre-release. Both create the release as a draft, attach the binaries, then publish it, because GitHub's immutable releases lock a release's assets once it is published.
 * <code>release-please.yml</code> manages versioning and releases (see below).
 
 Versions follow [https://www.conventionalcommits.org/ Conventional Commits], which release-please uses to generate the changelog and bump the version.

--- a/docs/Getting Started.wikitext
+++ b/docs/Getting Started.wikitext
@@ -86,4 +86,4 @@ echo '{{Note|Back up your wiki first.}}' >> src/index.wikitext
 
 Build again: the home page now shows the note. See [[Pages#Templates]] for parameters and more.
 
-{{prevnext|Binary|Pages}}
+{{prevnext|Installation|Pages}}

--- a/docs/Images.wikitext
+++ b/docs/Images.wikitext
@@ -14,7 +14,7 @@ You can also use your own image files. Put them in your source directory, next t
 
 PNG, GIF, JPEG, WebP, and SVG files are supported. Raster images are thumbnailed at build time; an SVG is rasterized to a thumbnail when a converter is available, otherwise served inline.
 
-The thumbnailing backend is detected from the tools present at build time: ImageMagick for raster images when it is installed (as in the Docker image), otherwise the built-in GD library (as in the standalone [[Binary|binary]], which carries GD); SVG uses librsvg when present, otherwise native inline rendering. The pages render the same either way, ImageMagick simply produces higher-quality thumbnails and supports more formats.
+The thumbnailing backend is detected from the tools present at build time: ImageMagick for raster images when it is installed (as in the Docker image), otherwise the built-in GD library (as in the standalone [[Standalone binary|binary]], which carries GD); SVG uses librsvg when present, otherwise native inline rendering. The pages render the same either way, ImageMagick simply produces higher-quality thumbnails and supports more formats.
 
 To give a file its own description page, add a wikitext file named after it in the <code>File:</code> namespace, the same way other namespaced pages are named. For <code>My photo.png</code>, that is <code>File:My photo.png.wikitext</code>.
 

--- a/docs/Installation.wikitext
+++ b/docs/Installation.wikitext
@@ -11,7 +11,7 @@ curl -L -o wikven https://github.com/chaotic-ground/wikven/releases/latest/downl
 chmod +x wikven
 </syntaxhighlight>
 
-On arm64, use <code>wikven-linux-aarch64</code>. See [[Binary|Standalone binary]] for installing it onto your <code>PATH</code>, nightly builds, and the optional host tools it uses.
+On arm64, use <code>wikven-linux-aarch64</code>. See [[Standalone binary]] for installing it onto your <code>PATH</code>, nightly builds, and the optional host tools it uses.
 
 == Docker ==
 
@@ -39,4 +39,4 @@ This produces a local <code>wikven</code> image you run exactly like the publish
 
 Once you have {{wikven}}, head to [[Getting Started]] to build your first site.
 
-{{prevnext|Why wikitext|Binary}}
+{{prevnext|Why wikitext|Getting Started}}

--- a/docs/MediaWiki:Sidebar.wikitext
+++ b/docs/MediaWiki:Sidebar.wikitext
@@ -3,7 +3,6 @@
 * Docs
 ** Why wikitext|Why wikitext
 ** Installation|Installation
-** Binary|Binary
 ** Getting Started|Getting Started
 ** Pages|Pages
 ** Editing sidebar|Editing sidebar
@@ -15,6 +14,7 @@
 ** Troubleshooting|Troubleshooting
 * References
 ** Configuration|Configuration
+** Standalone binary|Standalone binary
 ** Development|Development
 ** Version|Version
 ** Licenses|Licenses

--- a/docs/Standalone binary.wikitext
+++ b/docs/Standalone binary.wikitext
@@ -83,4 +83,4 @@ The binary renders on its own, but uses these host programs when they are presen
 
 {{note|Fetching over HTTPS, Wikimedia Commons images via InstantCommons and any [[Configuration#WikvenRepositories|third-party extensions or skins]], relies on your system's CA certificates. On a minimal system without them, install your distribution's CA bundle (for example the <code>ca-certificates</code> package). A site with only local content and images needs no network access.}}
 
-{{prevnext|Installation|Getting Started}}
+{{prevnext|Configuration|Development}}

--- a/docs/Troubleshooting.wikitext
+++ b/docs/Troubleshooting.wikitext
@@ -4,7 +4,7 @@ Common problems and what to check.
 
 == Thumbnails look low quality ==
 
-The [[Binary|standalone binary]] falls back to the built-in GD library, which produces lower-quality thumbnails and supports fewer formats. Install '''ImageMagick''' and '''librsvg''' on the build host for better output, or use the Docker image, which bundles them. See [[Images]].
+The [[Standalone binary|standalone binary]] falls back to the built-in GD library, which produces lower-quality thumbnails and supports fewer formats. Install '''ImageMagick''' and '''librsvg''' on the build host for better output, or use the Docker image, which bundles them. See [[Images]].
 
 == The search box does nothing ==
 


### PR DESCRIPTION
The maintainer flagged the Docs ordering as odd, and an independent review agreed. The curriculum ran **Why wikitext → Installation → Binary → Getting Started**, so a newcomer hit a deep-dive on one (Linux-only) install method before building anything, and Installation's own closing line ("head to Getting Started") disagreed with the footer, which sent readers to Binary instead.

`Installation` already summarises all three install methods (binary, Docker, build-from-source) and is enough to get going; the binary page is reference material (PATH install, nightly builds, checksum/provenance verification, optional host tools).

## Changes

**Docs (curriculum):** Why wikitext → Installation → **Getting Started** → Pages → … → Troubleshooting

**References:** Configuration → **Standalone binary** → Development → Version → Licenses

- Getting Started now follows Installation directly.
- `Binary.wikitext` → `Standalone binary.wikitext` (retitled to the term Installation already uses); every `[[Binary|…]]` link updated. Section anchors `[[Installation#Binary|…]]` stay (they point at Installation's install-method section, not the page).
- `prevnext` rewired: Installation ↔ Getting Started, and Configuration → Standalone binary → Development.

## Verification

Baked the docs: sidebar and the prev/next chain follow the new order, `Standalone_binary.html` resolves, old `Binary.html` is gone, no stale `[[Binary]]` page links remain.