### PR TITLE
fix: bump bundled SifterSearch to v0.6.0 (stop the double search box)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY includes/WikvenSettings.php /var/www/html/
 # SifterSearch (client-side Pagefind search) ships built in. Its release tarball carries the
 # per-arch Pagefind binary a git clone omits, so fetch the one matching this build's architecture.
 ARG TARGETARCH
-ARG SIFTERSEARCH_VERSION=v0.5.0
+ARG SIFTERSEARCH_VERSION=v0.6.0
 RUN arch="$TARGETARCH" \
  && if [ "$arch" = amd64 ]; then arch=x64; fi \
  && curl -fsSL "https://github.com/chaotic-ground/SifterSearch/releases/download/${SIFTERSEARCH_VERSION}/SifterSearch-linux-${arch}.tar.gz" \


### PR DESCRIPTION
## Bug

On the deployed docs site, **every page showed two search boxes**: the native one in the header plus a full PagefindUI box in the content.

## Cause

wikven's static export bundles every JS module into one self-executing file. SifterSearch's results-page module (`ext.sifter.results`) is server-queued only on the `SifterSearchResultsPage`, but once it's in the shared bundle it ran on **every** page and its `mount()` unconditionally created the PagefindUI. It was also unreachable on its own page (with `SifterSearchFullText: false` nothing linked to it).

## Fix

Bump the bundled SifterSearch from v0.5.0 → **v0.6.0**, which fixes this at the source:
- **#23** the results widget now guards on `wgSifterSearchOnResultsPage` and mounts only on the results page.
- **#30** a new `ext.sifter.retarget` module points the native search form at the results page, so submitting a query actually reaches it.

(SifterSearch v0.6.0 was released from chaotic-ground/SifterSearch's existing release-please PR.)

## Verification (local bake with the new image)

- **Installation / index**: one (native) search box, no PagefindUI, `wgSifterSearchOnResultsPage` absent.
- **Search**: native box + the full PagefindUI results widget; the search form's `action` is retargeted to `./Search.html` with the `title=Special:Search` hidden input removed.