### PR TITLE
test: add a Playwright browser smoke test for the static export

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,6 +19,10 @@ on:
       - 'i18n/**'
       - 'docs/**'
       - '.github/workflows/smoke.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playwright.config.js'
+      - 'tests/e2e/**'
   pull_request:
     paths:
       - 'Dockerfile'
@@ -31,6 +35,10 @@ on:
       - 'i18n/**'
       - 'docs/**'
       - '.github/workflows/smoke.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'playwright.config.js'
+      - 'tests/e2e/**'
 
 permissions:
   contents: read
@@ -76,3 +84,29 @@ jobs:
           fi
 
           echo "Smoke checks passed."
+
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
+        with:
+          node-version: 22
+
+      - name: Install the browser test tooling
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      # Serve dist under the site's own /wikven/ path prefix (as GitHub Pages does) so the
+      # Pagefind bundle and results page resolve, then drive it with a headless browser.
+      - name: Assert the rendered site in a browser
+        env:
+          WIKVEN_BASE_URL: http://127.0.0.1:8080/wikven/
+        run: |
+          mkdir -p pw-root
+          ln -sfn "$PWD/dist" pw-root/wikven
+          python3 -m http.server 8080 --directory pw-root &
+          server=$!
+          trap 'kill $server' EXIT
+          for _ in $(seq 1 30); do
+            curl -sf -o /dev/null "${WIKVEN_BASE_URL}index.html" && break
+            sleep 0.5
+          done
+          npm run test:e2e

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -85,10 +85,9 @@ jobs:
 
           echo "Smoke checks passed."
 
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
-        with:
-          node-version: 22
-
+      # Node.js is preinstalled on the runner; no setup-node (its caching trips
+      # the cache-poisoning audit, and this job shares a build cache with the
+      # image-publishing workflow).
       - name: Install the browser test tooling
         run: |
           npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /composer.lock
 /dist/
 /out/
+/test-results/
+/playwright-report/
 
 # OpenTofu / Terraform
 /.tf/.terraform/

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["package-lock.json"]

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,8 @@
 		"useIgnoreFile": true
 	},
 	"files": {
-		"ignoreUnknown": true
+		"ignoreUnknown": true,
+		"includes": ["**", "!package-lock.json"]
 	},
 	"formatter": {
 		"enabled": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+	"name": "wikven",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "wikven",
+			"license": "GPL-3.0-or-later",
+			"devDependencies": {
+				"@playwright/test": "^1.61.1"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "wikven",
+	"description": "Browser end-to-end tests for the wikven static export.",
+	"private": true,
+	"license": "GPL-3.0-or-later",
+	"scripts": {
+		"test:e2e": "playwright test"
+	},
+	"devDependencies": {
+		"@playwright/test": "^1.61.1"
+	}
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,12 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+// CI bakes docs/ to dist/, serves it under the site's own path prefix, and passes
+// the resulting base URL in WIKVEN_BASE_URL. The specs use paths relative to it.
+module.exports = defineConfig({
+	testDir: "./tests/e2e",
+	reporter: "line",
+	use: {
+		baseURL: process.env.WIKVEN_BASE_URL,
+		...devices["Desktop Chrome"],
+	},
+});

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,50 @@
+// Browser smoke tests for the baked static site. These catch regressions that
+// only surface once the page renders and its JS runs, which the static-HTML
+// assertions in the workflow cannot see (e.g. a search widget mounting on every
+// page, or the export quietly fetching from a server that is not there).
+
+const { test, expect } = require("@playwright/test");
+
+// URLs that only a live MediaWiki answers; a static export must request none.
+const BACKEND = /\/load\.php|\/api\.php|\/rest\.php\/|index\.php\?/;
+
+test("a content page shows one search box and no results widget", async ({
+	page,
+}) => {
+	const errors = [];
+	page.on("pageerror", (error) => errors.push(error.message));
+
+	await page.goto("Installation.html");
+
+	// The native search box is present, but the full Pagefind results widget is
+	// not: it must mount only on the results page, not on every page.
+	await expect(page.locator("#searchInput").first()).toBeVisible();
+	await expect(page.locator(".pagefind-ui__form")).toHaveCount(0);
+
+	expect(errors, errors.join("; ")).toEqual([]);
+});
+
+test("a content page fetches nothing from a live backend", async ({ page }) => {
+	const backend = [];
+	page.on("request", (request) => {
+		if (BACKEND.test(request.url())) {
+			backend.push(request.url());
+		}
+	});
+
+	await page.goto("Installation.html", { waitUntil: "load" });
+	await page.waitForTimeout(1000);
+
+	expect(backend, backend.join("; ")).toEqual([]);
+});
+
+test("the results page mounts the widget and returns results", async ({
+	page,
+}) => {
+	await page.goto("Search.html?search=wikven");
+
+	await expect(page.locator(".pagefind-ui__form")).toHaveCount(1);
+	await expect(page.locator(".pagefind-ui__result").first()).toBeVisible({
+		timeout: 15000,
+	});
+});


### PR DESCRIPTION
## Why

`smoke.yml` only inspects the **static HTML** (main page present, no `load.php` in dumped CSS). A class of regressions that only appear once the page **renders and its JS runs** slipped through — most recently the SifterSearch results widget mounting on *every* page (the "two search boxes" bug), which passed every static check.

## What

A headless-browser smoke test (**Playwright**, chromium) that drives the baked site and asserts what static grep can't:

- a content page shows the native search box and **no** results widget, with **no uncaught JS errors**;
- a content page makes **zero requests to a live backend** (`load.php`, action/REST APIs) — proving the export is self-contained (stronger than grepping CSS);
- the **results page** mounts the widget and actually **returns results**.

Wired into `smoke.yml` after the existing bake: `dist` is served under the site's own `/wikven/` path prefix (as GitHub Pages does) so the Pagefind bundle and results page resolve, then driven with a browser.

Introduces a minimal `package.json` + lockfile for `@playwright/test` (the repo had no npm footprint); `biome` and `typos` skip the lockfile, Playwright output dirs are gitignored.

## Why Playwright (not Quibble/Selenium)

wikven's bugs live in the **static export**, which behaves differently from a live wiki (self-executing bundle, `load.php` stripped, cli-only chrome hidden). Quibble Selenium tests a **live MediaWiki**, so it can't reproduce them. This test runs against the baked `dist`. Playwright's request interception (the "no backend calls" assertion) and auto-waiting fit these checks directly.

## Verification

Locally the 3 tests pass on the current build, and the first test **fails** when a stray `.pagefind-ui__form` is injected into a content page (confirming it guards the exact regression). Run: serve `dist` under `/wikven/`, `WIKVEN_BASE_URL=… npm run test:e2e`.