### PR TITLE
ci: dedupe identical push/pull_request path filters with a YAML anchor

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,11 +4,10 @@ name: Docker image
 on:
   push:
     branches: [main]
-    paths-ignore:
+    paths-ignore: &paths-ignore
       - 'docs/**'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
+    paths-ignore: *paths-ignore
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,7 +8,7 @@ name: Smoke test
 on:
   push:
     branches: [main]
-    paths:
+    paths: &paths
       - 'Dockerfile'
       - 'bin/entrypoint'
       - 'default.yml'
@@ -24,21 +24,7 @@ on:
       - 'playwright.config.js'
       - 'tests/e2e/**'
   pull_request:
-    paths:
-      - 'Dockerfile'
-      - 'bin/entrypoint'
-      - 'default.yml'
-      - 'extension.json'
-      - 'includes/**'
-      - 'maintenance/**'
-      - 'resources/**'
-      - 'i18n/**'
-      - 'docs/**'
-      - '.github/workflows/smoke.yml'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'playwright.config.js'
-      - 'tests/e2e/**'
+    paths: *paths
 
 permissions:
   contents: read

--- a/.github/workflows/tf.yml
+++ b/.github/workflows/tf.yml
@@ -3,15 +3,13 @@ name: Tofu
 
 on:
   pull_request:
-    paths:
+    paths: &paths
       - ".tf/**"
       - .github/workflows/tf.yml
   push:
     branches:
       - main
-    paths:
-      - ".tf/**"
-      - .github/workflows/tf.yml
+    paths: *paths
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
`smoke.yml`, `docker-build.yml`, and `tf.yml` each listed the same `paths` (or `paths-ignore`) twice, once under `push` and once under `pull_request`. Anchor the list on the first trigger and alias it on the second, so the two can't drift.

```yaml
on:
  push:
    paths: &paths
      - '...'
  pull_request:
    paths: *paths
```

YAML anchors are file-scoped and resolved at parse time (supported by GitHub Actions). Verified with a real YAML parser that each file's resolved `push` and `pull_request` filters are identical to before (smoke 14 entries, docker-build 1, tf 2). This PR also live-confirms parsing: it edits all three workflows, so `smoke` and `tf` (which trigger on changes to themselves) and `docker-build` (paths-ignore `docs/**`) should all run here.