### PR TITLE
build(deps): pin quibble-action to v2.0.1 (GitHub-mirror clones)

### DIFF
--- a/.github/workflows/quibble.yml
+++ b/.github/workflows/quibble.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      - uses: femiwiki/quibble-action@9964af476e606e1dc7e14ee13db34f99456f3c41  # main
+      - uses: femiwiki/quibble-action@d799e5bb348756ea1588f2b5f2ca7fc09fdbdac9  # v2.0.1
         with:
           stage: phan
           mediawiki-version: ${{ matrix.mediawiki-version }}
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
-      - uses: femiwiki/quibble-action@9964af476e606e1dc7e14ee13db34f99456f3c41  # main
+      - uses: femiwiki/quibble-action@d799e5bb348756ea1588f2b5f2ca7fc09fdbdac9  # v2.0.1
         with:
           stage: composer-test
           mediawiki-version: REL1_45
@@ -50,7 +50,7 @@ jobs:
         with:
           persist-credentials: false
       - id: quibble
-        uses: femiwiki/quibble-action@9964af476e606e1dc7e14ee13db34f99456f3c41  # main
+        uses: femiwiki/quibble-action@d799e5bb348756ea1588f2b5f2ca7fc09fdbdac9  # v2.0.1
         with:
           stage: coverage
           # Coverage tooling lives only on MediaWiki master.


### PR DESCRIPTION
quibble-action **v2.0.1** switched the MediaWiki/dependency clones from Gerrit to the official GitHub mirrors (with a `git-source` input to opt back into Gerrit), ending the intermittent **Gerrit HTTP 429** CI failures. Pins the three quibble jobs (phan matrix, composer-test, coverage) to the **release tag's commit** (`d799e5b`, `# v2.0.1`) rather than a moving-main SHA, so Dependabot keeps it current like the other pinned actions.

Validated downstream before this bump: chaotic-ground/SifterSearch#35 temporarily pinned the same code via a DO-NOT-MERGE commit and its full Quibble matrix passed on the first attempt (https://github.com/chaotic-ground/SifterSearch/actions/runs/28630732095). This PR's own phan/composer-test/coverage checks exercise the mirror path here too.